### PR TITLE
Fix DB creation

### DIFF
--- a/backend/gncitizen/core/taxonomy/models.py
+++ b/backend/gncitizen/core/taxonomy/models.py
@@ -13,7 +13,7 @@ class BibNoms(db.Model):
         db.Integer,
         nullable=True, unique=True
     )
-    cd_ref = db.Column(db.Integer)
+    cd_ref = db.Column(db.Integer, unique=True)
     nom_francais = db.Column(db.Unicode)
     comments = db.Column(db.Unicode)
 

--- a/backend/gncitizen/utils/utilssqlalchemy.py
+++ b/backend/gncitizen/utils/utilssqlalchemy.py
@@ -28,6 +28,8 @@ def create_schemas(db):
     '''Créée les schémas lors du premier lancement de l'application'''
     db.session.execute('CREATE SCHEMA IF NOT EXISTS gnc_core')
     db.session.execute('CREATE SCHEMA IF NOT EXISTS gnc_obstax')
+    db.session.execute('CREATE SCHEMA IF NOT EXISTS taxonomie')
+    db.session.execute('CREATE SCHEMA IF NOT EXISTS ref_geo')
     db.session.commit()
 
 


### PR DESCRIPTION
A couple schemas were missing from the list during server startup / lazy db creation.

Also table `t_medias` has a FK on `bib_noms.cd_ref` but that column was missing a `UNIQUE` constraints so creation was failing.