### PR TITLE
Dev (IGN Map and GeoLocation in map form)

### DIFF
--- a/backend/gncitizen/core/commons/routes.py
+++ b/backend/gncitizen/core/commons/routes.py
@@ -91,6 +91,7 @@ def get_module(pk):
         datas = ModulesModel.query.filter_by(id_module=pk).first()
         return datas.as_dict(), 200
     except Exception as e:
+        current_app.logger.critical("[get_module] error : %s", str(e))
         return {"message": str(e)}, 400
 
 
@@ -114,6 +115,7 @@ def get_modules():
             datas.append(d)
         return {"count": count, "datas": datas}, 200
     except Exception as e:
+        current_app.logger.critical("[get_modules] error : %s", str(e))
         return {"message": str(e)}, 400
 
 
@@ -136,14 +138,19 @@ def get_program(pk):
          """
     try:
         datas = ProgramsModel.query.filter_by(id_program=pk, is_active=True).limit(1)
-        features = []
-        for data in datas:
-            feature = data.get_geofeature()
-            # for k, v in data:
-            #     feature['properties'][k] = v
-            features.append(feature)
-        return {"features": features}, 200
+        if datas.count() != 1:
+          current_app.logger.warning("[get_program] Program not found")        
+          return {"message": "Program not found"}, 400
+        else:
+          features = []
+          for data in datas:
+              feature = data.get_geofeature()
+              # for k, v in data:
+              #     feature['properties'][k] = v
+              features.append(feature)
+          return {"features": features}, 200
     except Exception as e:
+        current_app.logger.critical("[get_program] error : %s", str(e))
         return {"message": str(e)}, 400
 
 
@@ -184,6 +191,7 @@ def get_programs():
         feature_collection["count"] = count
         return feature_collection
     except Exception as e:
+        current_app.logger.critical("[get_programs] error : %s", str(e))
         return {"message": str(e)}, 400
 
 
@@ -278,4 +286,5 @@ def post_program():
             200,
         )
     except Exception as e:
+        current_app.logger.critical("[post_program] error : %s", str(e))
         return {"message": str(e)}, 400

--- a/frontend/src/app/programs/observations/form/form.component.ts
+++ b/frontend/src/app/programs/observations/form/form.component.ts
@@ -1,3 +1,4 @@
+import { MAP_CONFIG } from './../../../../conf/map.config';
 import * as L from 'leaflet';
 import {
   AbstractControl,
@@ -49,13 +50,18 @@ import 'leaflet-fullscreen/dist/Leaflet.fullscreen';
 
 declare let $: any;
 
-const PROGRAM_AREA_STYLE = {
-  fillColor: "transparent",
-  weight: 2,
-  opacity: 0.8,
-  color: "red",
-  dashArray: "4"
-};
+
+const map_conf = {
+  GEOLOCATION_CONTROL_POSITION: "topright",
+  GEOLOCATION_HIGH_ACCURACY: false,
+  PROGRAM_AREA_STYLE: {
+    fillColor: "transparent",
+    weight: 2,
+    opacity: 0.8,
+    color: "red",
+    dashArray: "4"
+  }
+}
 const taxonSelectInputThreshold = AppConfig.taxonSelectInputThreshold;
 const taxonAutocompleteInputThreshold =
   AppConfig.taxonAutocompleteInputThreshold;
@@ -227,6 +233,19 @@ export class ObsFormComponent implements AfterViewInit {
           }
         }).addTo(formMap);
 
+        L.control.locate({
+          position: map_conf.GEOLOCATION_CONTROL_POSITION,
+          getLocationBounds: locationEvent =>
+            locationEvent.bounds.extend(L.LatLngBounds),
+          onLocationError: locationEvent =>
+            alert('Vous semblez être en dehors de la zone du programme'),
+          locateOptions: {
+            enableHighAccuracy: map_conf.GEOLOCATION_HIGH_ACCURACY
+
+          }
+        })
+        .addTo(formMap);
+
         let ZoomViewer = L.Control.extend({
           onAdd: () => {
             let container = L.DomUtil.create("div");
@@ -249,13 +268,14 @@ export class ObsFormComponent implements AfterViewInit {
 
         const programArea = L.geoJSON(this.program, {
           style: function(_feature) {
-            return PROGRAM_AREA_STYLE;
+            return map_conf.PROGRAM_AREA_STYLE;
           }
         }).addTo(formMap);
 
         const maxBounds: L.LatLngBounds = programArea.getBounds();
         formMap.fitBounds(maxBounds);
         formMap.setMaxBounds(maxBounds.pad(0.01));
+
 
         // Set initial observation marker from main map if already spotted
         let myMarker = null;

--- a/frontend/src/app/programs/observations/form/form.component.ts
+++ b/frontend/src/app/programs/observations/form/form.component.ts
@@ -32,7 +32,6 @@ import { FeatureCollection } from 'geojson';
 import { GncProgramsService } from '../../../api/gnc-programs.service';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { LeafletMouseEvent } from 'leaflet';
-import { MAP_CONFIG } from '../../../../conf/map.config';
 import { NgbDate } from '@ng-bootstrap/ng-bootstrap';
 import { Observable } from 'rxjs';
 import {
@@ -241,7 +240,6 @@ export class ObsFormComponent implements AfterViewInit {
             alert('Vous semblez être en dehors de la zone du programme'),
           locateOptions: {
             enableHighAccuracy: map_conf.GEOLOCATION_HIGH_ACCURACY
-
           }
         })
         .addTo(formMap);

--- a/frontend/src/app/programs/observations/map/map.component.ts
+++ b/frontend/src/app/programs/observations/map/map.component.ts
@@ -33,7 +33,9 @@ const conf = {
       attribution: baseLayer["attribution"],
       detectRetina: baseLayer["detectRetina"],
       maxZoom: baseLayer["maxZoom"],
-      bounds: baseLayer["bounds"]
+      bounds: baseLayer["bounds"],
+      apiKey: baseLayer["apiKey"],
+      layerName: baseLayer["layerName"],
     };
     if (baseLayer["subdomains"]) {
       layerConf.subdomains = baseLayer["subdomains"];

--- a/frontend/src/conf/map.config.ts.sample
+++ b/frontend/src/conf/map.config.ts.sample
@@ -1,68 +1,88 @@
 export const MAP_CONFIG = {
-  DEFAULT_PROVIDER: "OpenStreetMapFRHot",
+  DEFAULT_PROVIDER: "OpenStreetMapOrg",
   BASEMAPS: [
-  {
-    name: "OpenStreetMapOrg",
-    maxZoom: 19,
-    layer: "//{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
-    subdomains: "abc",
-    attribution:
-      '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, Tiles style by <a href="https://www.hotosm.org/" target="_blank">Humanitarian OpenStreetMap Team</a> hosted by <a href="https://openstreetmap.fr/" target="_blank">OpenStreetMap France</a>'
-  },
-  {
-    name: "OpenStreetMapFRHot",
-    maxZoom: 19,
-    layer: "//{s}.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png",
-    subdomains: "abc",
-    attribution:
-      '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, Tiles style by <a href="https://www.hotosm.org/" target="_blank">Humanitarian OpenStreetMap Team</a> hosted by <a href="https://openstreetmap.fr/" target="_blank">OpenStreetMap France</a>'
-  },
-  // {
-  //   name: "OpenStreetMapCH",
-  //   maxZoom: 18,
-  //   layer: "//tile.osm.ch/switzerland/{z}/{x}/{y}.png",
-  //   subdomains: "abc",
-  //   attribution:
-  //     '&copy; <a href="&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
-  //   bounds: [[45, 5], [48, 11]]
-  // },
-  // {
-  //   name: "OpenStreetMapDE",
-  //   maxZoom: 18,
-  //   layer: "//{s}.tile.openstreetmap.de/tiles/osmde/{z}/{x}/{y}.png",
-  //   subdomains: "abc",
-  //   attribution:
-  //     '&copy; <a href="&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
-  // },
-  // {
-  //   name: "OpenStreetMapBZH",
-  //   maxZoom: 18,
-  //   layer: "//tile.openstreetmap.bzh/br/{z}/{x}/{y}.png",
-  //   subdomains: "",
-  //   attribution:
-  //     '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, Tiles courtesy of <a href="http://www.openstreetmap.bzh/" target="_blank">Breton OpenStreetMap Team</a>',
-  //   bounds: [[46.2, -5.5], [50, 0.7]]
-  // },
-  {
-    name: "OpenTopoMap",
-    maxZoom: 17,
-    layer: "//{s}.opentopomap.org/{z}/{x}/{y}.png",
-    subdomains: "abc",
-    attribution: "© OpenTopoMap"
-  },
-  {
-    // ⚠ google's terms&conditions
-    // https://github.com/Leaflet/Leaflet/blob/master/FAQ.md#i-want-to-use-google-maps-api-tiles-with-leaflet-can-i-do-that
-    name: "GoogleSatellite",
-    maxZoom: 20,
-    layer: "//mt{s}.google.com/vt/lyrs=s&x={x}&y={y}&z={z}",
-    subdomains: "1",
-    attribution: "© GoogleMap"
-  }
-],
- CENTER: [46.52863469527167, 2.43896484375],
- ZOOM_LEVEL: 6,
- ZOOM_LEVEL_RELEVE: 15,
- NEW_OBS_POINTER: "assets/pointer-blue2.png",
- OBS_POINTER: "assets/pointer-green.png"
+    {
+      name: "OpenStreetMapOrg",
+      maxZoom: 19,
+      layer: "//{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
+      subdomains: "abc",
+      attribution:
+        '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, Tiles style by <a href="https://www.hotosm.org/" target="_blank">Humanitarian OpenStreetMap Team</a> hosted by <a href="https://openstreetmap.fr/" target="_blank">OpenStreetMap France</a>'
+    },
+    // {
+    //   name: "OpenStreetMapFRHot",
+    //   maxZoom: 19,
+    //   layer: "//{s}.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png",
+    //   subdomains: "abc",
+    //   attribution:
+    //     '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, Tiles style by <a href="https://www.hotosm.org/" target="_blank">Humanitarian OpenStreetMap Team</a> hosted by <a href="https://openstreetmap.fr/" target="_blank">OpenStreetMap France</a>'
+    // },
+    // {
+    //   name: "OpenStreetMapCH",
+    //   maxZoom: 18,
+    //   layer: "//tile.osm.ch/switzerland/{z}/{x}/{y}.png",
+    //   subdomains: "abc",
+    //   attribution:
+    //     '&copy; <a href="&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+    //   bounds: [[45, 5], [48, 11]]
+    // },
+    // {
+    //   name: "OpenStreetMapDE",
+    //   maxZoom: 18,
+    //   layer: "//{s}.tile.openstreetmap.de/tiles/osmde/{z}/{x}/{y}.png",
+    //   subdomains: "abc",
+    //   attribution:
+    //     '&copy; <a href="&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+    // },
+    // {
+    //   name: "OpenStreetMapBZH",
+    //   maxZoom: 18,
+    //   layer: "//tile.openstreetmap.bzh/br/{z}/{x}/{y}.png",
+    //   subdomains: "",
+    //   attribution:
+    //     '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, Tiles courtesy of <a href="http://www.openstreetmap.bzh/" target="_blank">Breton OpenStreetMap Team</a>',
+    //   bounds: [[46.2, -5.5], [50, 0.7]]
+    // },
+    {
+      name: "OpenTopoMap",
+      maxZoom: 17,
+      layer: "//{s}.opentopomap.org/{z}/{x}/{y}.png",
+      subdomains: "abc",
+      attribution: "© OpenTopoMap"
+    },
+    {
+      name: "IGN Vue satellite",
+      maxZoom: 17,
+      layer: "https://wxs.ign.fr/{apiKey}/geoportail/wmts?&REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE=normal&TILEMATRIXSET=PM&FORMAT=image/jpeg&LAYER={layerName}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+      layerName: "ORTHOIMAGERY.ORTHOPHOTOS",
+      // Remplacer "pratique" par votre clé IGN
+      apiKey: 'pratique',
+      subdomains: "abc",
+      attribution: "© IGN-F/Geoportail"
+    },
+    {
+      name: "IGN Cartes",
+      maxZoom: 17,
+      layer: "https://wxs.ign.fr/{apiKey}/geoportail/wmts?&REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE=normal&TILEMATRIXSET=PM&FORMAT=image/jpeg&LAYER={layerName}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
+      layerName: "GEOGRAPHICALGRIDSYSTEMS.MAPS",
+      // Remplacer "pratique" par votre clé IGN
+      apiKey: 'pratique',
+      subdomains: "abc",
+      attribution: "© IGN-F/Geoportail"
+    },
+    // {
+    //   // ⚠ google's terms&conditions
+    //   // https://github.com/Leaflet/Leaflet/blob/master/FAQ.md#i-want-to-use-google-maps-api-tiles-with-leaflet-can-i-do-that
+    //   name: "GoogleSatellite",
+    //   maxZoom: 20,
+    //   layer: "//mt{s}.google.com/vt/lyrs=s&x={x}&y={y}&z={z}",
+    //   subdomains: "1",
+    //   attribution: "© GoogleMap"
+    // }
+  ],
+  CENTER: [46.52863469527167, 2.43896484375],
+  ZOOM_LEVEL: 6,
+  ZOOM_LEVEL_RELEVE: 15,
+  NEW_OBS_POINTER: "assets/pointer-blue2.png",
+  OBS_POINTER: "assets/pointer-green.png"
 }

--- a/frontend/src/conf/map.config.ts.sample
+++ b/frontend/src/conf/map.config.ts.sample
@@ -2,21 +2,21 @@ export const MAP_CONFIG = {
   DEFAULT_PROVIDER: "OpenStreetMapFRHot",
   BASEMAPS: [
   {
-    name: "OpenStreetMap",
+    name: "OpenStreetMapOrg",
     maxZoom: 19,
     layer: "//{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
     subdomains: "abc",
     attribution:
       '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, Tiles style by <a href="https://www.hotosm.org/" target="_blank">Humanitarian OpenStreetMap Team</a> hosted by <a href="https://openstreetmap.fr/" target="_blank">OpenStreetMap France</a>'
   },
-  // {
-  //   name: "OpenStreetMapFRHot",
-  //   maxZoom: 19,
-  //   layer: "//{s}.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png",
-  //   subdomains: "abc",
-  //   attribution:
-  //     '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, Tiles style by <a href="https://www.hotosm.org/" target="_blank">Humanitarian OpenStreetMap Team</a> hosted by <a href="https://openstreetmap.fr/" target="_blank">OpenStreetMap France</a>'
-  // },
+  {
+    name: "OpenStreetMapFRHot",
+    maxZoom: 19,
+    layer: "//{s}.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png",
+    subdomains: "abc",
+    attribution:
+      '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, Tiles style by <a href="https://www.hotosm.org/" target="_blank">Humanitarian OpenStreetMap Team</a> hosted by <a href="https://openstreetmap.fr/" target="_blank">OpenStreetMap France</a>'
+  },
   // {
   //   name: "OpenStreetMapCH",
   //   maxZoom: 18,
@@ -50,18 +50,6 @@ export const MAP_CONFIG = {
     subdomains: "abc",
     attribution: "© OpenTopoMap"
   },
-    // {
-  //   name: "Stamen",
-  //   // layer: "http://{s}.tile.stamen.com/terrain/{z}/{x}/{y}.jpg",
-  //   // layer: "http://{s}.tile.stamen.com/watercolor/{z}/{x}/{y}.jpg",
-  //   // layer:
-  //   //   "https://stamen-tiles-{s}.a.ssl.fastly.net/watercolor/{z}/{x}/{y}.jpg",
-  //   // maxZoom: 22,
-  //   layer: "http://{s}.tile.stamen.com/toner-lite/{z}/{x}/{y}.png",
-  //   maxZoom: 20,
-  //   subdomains: "abcd",
-  //   attribution: "maps.stamen.com"
-  // },
   {
     // ⚠ google's terms&conditions
     // https://github.com/Leaflet/Leaflet/blob/master/FAQ.md#i-want-to-use-google-maps-api-tiles-with-leaflet-can-i-do-that


### PR DESCRIPTION
## Frontend:
- :gift: L'ajout de fonds de carte IGN est maintenant possible. Il suffit de renseigner dans le fichier `map.config.ts` la clé IGN dans `apiKey` (ou n'importe quel autre provider d'ailleurs) et le nom de la couche dans `layerName` (`GEOGRAPHICALGRIDSYSTEMS.MAPS` ou `ORTHOIMAGERY.ORTHOPHOTOS` par exemple). Deux exemples dans le fichier type `map.config.ts.sample` avec le compte IGN Pratique
:warning: Pour le moment, il n'est pas possible de sélectionner les couches dans la carte du formulaire.

- :triangular_flag_on_post: La géolocalisation est maintenant disponible sur le formulaire de saisie d'une observation.

## Backend
- :beetle: Amélioration de l'API, si aucun programme n'existe à l'url `api/programs/|id]`, l'API renvoie un message d'erreur indiquant qu'aucun programme n'existe.
- :loudspeaker: Modif et ajout de quelques messages de logs.