### PR TITLE
Disable signup

### DIFF
--- a/frontend/src/app/core/topbar/topbar.component.html
+++ b/frontend/src/app/core/topbar/topbar.component.html
@@ -26,7 +26,7 @@
             </a>
                     </li>
                 </ul>
-                <div class="btn-group">
+                <div class="btn-group" *ngIf="canSignup">
                     <div *ngIf="(isLoggedIn() | async); then: connected; else: disconnected"></div>
                     <ng-template #connected>
                         <a placement="bottom" i18n-ngbTooltip ngbTooltip="Mon tableau de bord" routerLink="mydashboard" routerLinkActive="active">

--- a/frontend/src/app/core/topbar/topbar.component.ts
+++ b/frontend/src/app/core/topbar/topbar.component.ts
@@ -27,6 +27,7 @@ export class TopbarComponent implements OnInit {
   programs$ = new Subject<Program[]>();
   isAdmin = false;
   canDisplayAbout: boolean = AppConfig.about;
+  canSignup: boolean = AppConfig.signup;
   adminUrl: SafeUrl;
 
   constructor(

--- a/frontend/src/app/programs/observations/modalflow/steps/onboard/onboard.component.ts
+++ b/frontend/src/app/programs/observations/modalflow/steps/onboard/onboard.component.ts
@@ -13,6 +13,7 @@ import { NgbModal, NgbModalRef } from "@ng-bootstrap/ng-bootstrap";
 import { IFlowComponent } from "../../flow/flow";
 import { RegisterComponent } from "../../../../../auth/register/register.component";
 import { LoginComponent } from "../../../../../auth/login/login.component";
+import { AppConfig } from "../../../../../../conf/app.config";
 import { AuthService } from "../../../../../auth/auth.service";
 
 @Component({
@@ -38,6 +39,9 @@ export class OnboardComponent implements IFlowComponent, OnInit {
     this.authService.authorized$.subscribe(value => {
       if (value) {
         this.timeout = setTimeout(() => this.data.next(), 0);
+      }
+      if (!AppConfig.signup) { 
+        this.data.next(); 
       }
     });
   }

--- a/frontend/src/conf/app.config.ts.sample
+++ b/frontend/src/conf/app.config.ts.sample
@@ -16,6 +16,7 @@ export const AppConfig = {
       fr: "assets/cgu.pdf",
       en: "assets/termsOfUse.pdf"
     },
+    signup:true,
     platform_intro: {
       fr: "Bienvenue<br /> sur GeoNature Citizen",
       en: "Welcome<br /> on GeoNature Citizen"


### PR DESCRIPTION
Ajout d'un paramètre au niveau du front pour désactiver la possibilité d'inscription (observations sans compte uniquement). Je n'ai rien modifier dans le backend car ca ne me parait pas vraiment nécessaire de bloquer la création de compte au niveau du backend.

A voir pour ajouter un champs nom/pseudo lors de la saisie de l'obs si ce mode est activé.