### PR TITLE
champs optionnel contact email

### DIFF
--- a/frontend/src/app/programs/observations/form/form.component.html
+++ b/frontend/src/app/programs/observations/form/form.component.html
@@ -136,6 +136,7 @@
         ></textarea>
       </div>
 
+
       <div class="form-group col-lg-12 btn position-relative">
         <label for="photo" i18n
           ><i class="fa fa-camera"></i>Ajouter une photo</label
@@ -151,7 +152,29 @@
           capture="environment"
         />
       </div>
+       <div class="form-check col-lg-12" *ngIf="AppConfig.email_contact">
+              <input 
+                class="form-check-input"
+                type="checkbox" 
+                id="agreeContactRGPD" 
+                formControlName="agreeContactRGPD"
+                (change)=onChangeContactCheckBoxRGPD()
+              />
+              <label class="form-check-label" for="agreeContactRGPD" >{{ AppConfig.program_allow_email_contact[localeId] }}</label>
+        </div>
+        <div class="form-group form-inline col-lg-12" *ngIf="AppConfig.email_contact">
+              <label for="email" style="margin-right:5px" i18n>E-mail de contact </label>
+              <input
+                class="form-control"
+                type="text"
+                i18n-placeholder
+                placeholder="E-Mail"
+                id="email"
+                formControlName="email"
+              />
+        </div>
     </div>
+
 
     <div class="form-group col-lg-6 col-md-12 half">
       <h5 i18n>Où avez-vous observé cette espèce ?</h5>

--- a/frontend/src/app/programs/observations/form/form.component.html
+++ b/frontend/src/app/programs/observations/form/form.component.html
@@ -152,27 +152,7 @@
           capture="environment"
         />
       </div>
-       <div class="form-check col-lg-12" *ngIf="AppConfig.email_contact">
-              <input 
-                class="form-check-input"
-                type="checkbox" 
-                id="agreeContactRGPD" 
-                formControlName="agreeContactRGPD"
-                (change)=onChangeContactCheckBoxRGPD()
-              />
-              <label class="form-check-label" for="agreeContactRGPD" >{{ AppConfig.program_allow_email_contact[localeId] }}</label>
-        </div>
-        <div class="form-group form-inline col-lg-12" *ngIf="AppConfig.email_contact">
-              <label for="email" style="margin-right:5px" i18n>E-mail de contact </label>
-              <input
-                class="form-control"
-                type="text"
-                i18n-placeholder
-                placeholder="E-Mail"
-                id="email"
-                formControlName="email"
-              />
-        </div>
+      
     </div>
 
 
@@ -209,6 +189,27 @@
           observation</em
         >
       </p>
+
+             <div class="col-lg-12" *ngIf="AppConfig.email_contact">
+                          <input 
+                            type="checkbox" 
+                            id="agreeContactRGPD" 
+                            formControlName="agreeContactRGPD"
+                            (change)=onChangeContactCheckBoxRGPD()
+                          />
+                          <small style="margin-left:5px">{{ AppConfig.program_allow_email_contact[localeId] }}</small>
+                    </div>
+                    <div class="form-group col-lg-12" *ngIf="AppConfig.email_contact">
+                          <label for="email" style="margin-right:5px" i18n>E-mail de contact </label>
+                          <input
+                            type="text"
+                            i18n-placeholder
+                            placeholder="E-Mail"
+                            id="email"
+                            formControlName="email"
+                          />
+                    </div>
+
     </div>
     <p
       class="ng-invalid ng-dirty pl-1 ml-1"

--- a/frontend/src/app/programs/observations/form/form.component.html
+++ b/frontend/src/app/programs/observations/form/form.component.html
@@ -190,7 +190,7 @@
         >
       </p>
 
-             <div class="col-lg-12" *ngIf="AppConfig.email_contact">
+             <div class="col-lg-12" *ngIf="AppConfig.email_contact && !(isLoggedIn() | async)">
                           <input 
                             type="checkbox" 
                             id="agreeContactRGPD" 
@@ -199,7 +199,7 @@
                           />
                           <small style="margin-left:5px">{{ AppConfig.program_allow_email_contact[localeId] }}</small>
                     </div>
-                    <div class="form-group col-lg-12" *ngIf="AppConfig.email_contact">
+                    <div class="form-group col-lg-12" *ngIf="AppConfig.email_contact && !(isLoggedIn() | async)">
                           <label for="email" style="margin-right:5px" i18n>E-mail de contact </label>
                           <input
                             type="text"

--- a/frontend/src/app/programs/observations/form/form.component.ts
+++ b/frontend/src/app/programs/observations/form/form.component.ts
@@ -21,6 +21,7 @@ import {
   ViewEncapsulation
 } from "@angular/core";
 import { AppConfig } from "../../../../conf/app.config";
+import { AuthService } from "./../../../auth/auth.service";
 import {
   debounceTime,
   distinctUntilChanged,
@@ -199,7 +200,8 @@ export class ObsFormComponent implements AfterViewInit {
     private http: HttpClient,
     private programService: GncProgramsService,
     private route: ActivatedRoute,
-    private toastr: ToastrService
+    private toastr: ToastrService,
+    private auth: AuthService
   ) {}
 
   ngAfterViewInit() {
@@ -414,6 +416,14 @@ export class ObsFormComponent implements AfterViewInit {
       `${this.URL}/observations`,
       formData,
       httpOptions
+    );
+  }
+
+  isLoggedIn(): Observable<boolean> {
+    return this.auth.authorized$.pipe(
+      map(value => {
+        return value;
+      })
     );
   }
 

--- a/frontend/src/app/programs/observations/form/form.component.ts
+++ b/frontend/src/app/programs/observations/form/form.component.ts
@@ -122,7 +122,9 @@ export class ObsFormComponent implements AfterViewInit {
         Validators.required,
         geometryValidator()
       ]),
-      id_program: new FormControl(this.program_id)
+      id_program: new FormControl(this.program_id),
+      email: new FormControl({value:'',disabled:true}),
+      agreeContactRGPD: new FormControl(""),
     }
     //{ updateOn: "submit" }
   );
@@ -340,6 +342,11 @@ export class ObsFormComponent implements AfterViewInit {
     this.obsForm.controls["cd_nom"].patchValue(taxon.taxref["cd_nom"]);
   }
 
+  onChangeContactCheckBoxRGPD(): void{
+      this.obsForm.controls["agreeContactRGPD"].value ?  this.obsForm.controls["email"].enable() : this.obsForm.controls["email"].disable(); 
+      this.obsForm.controls["email"].setValue('');
+  };
+
   isSelectedTaxon(taxon: TaxonomyListItem): boolean {
     return this.selectedTaxon === taxon;
   }
@@ -399,7 +406,7 @@ export class ObsFormComponent implements AfterViewInit {
       .match(/\d{4}-\d{2}-\d{2}/)[0];
     formData.append("date", normDate);
 
-    for (let item of ["count", "comment", "id_program"]) {
+    for (let item of ["count", "comment", "id_program","email"]) {
       formData.append(item, this.obsForm.get(item).value);
     }
 

--- a/frontend/src/conf/app.config.ts.sample
+++ b/frontend/src/conf/app.config.ts.sample
@@ -16,6 +16,8 @@ export const AppConfig = {
       fr: "assets/cgu.pdf",
       en: "assets/termsOfUse.pdf"
     },
+    signup:true,
+    email_contact:false,
     platform_intro: {
       fr: "Bienvenue<br /> sur GeoNature Citizen",
       en: "Welcome<br /> on GeoNature Citizen"
@@ -35,6 +37,10 @@ export const AppConfig = {
     program_add_an_observation: {
       fr: "AJOUTER UNE OBSERVATION",
       en: "CONTRIBUTE AN OBSERVATION"
+    },
+    program_allow_email_contact: {
+      fr: "J'accepte que mon adresse e-mail puisse être utilisée pour recontacter à propos de mon observation",
+      en : "I agree that my e-mail address can be used to recontact about my observation"
     },
     taxonSelectInputThreshold: 7,
     taxonAutocompleteInputThreshold: 12,


### PR DESCRIPTION
Ajout d'un champs optionnel (paramétrable) permettant à l'utilisateur de saisir son e-mail pour être recontacté (utile si les inscriptions ne sont pas autorisée)
#47 