### PR TITLE
affichage noms observateurs parametrable

### DIFF
--- a/frontend/src/app/programs/observations/list/list.component.html
+++ b/frontend/src/app/programs/observations/list/list.component.html
@@ -34,7 +34,7 @@
         " />
       <div class="infos">
         <h5 i18n>{{ !!o.properties.nom_francais ? o.properties.nom_francais : o.properties.taxref?.nom_vern }}</h5>
-        <p i18n>
+        <p i18n *ngIf="AppConfig.program_list_observers_names">
           Observé par
           <span>{{
             o.properties.observer?.username

--- a/frontend/src/conf/app.config.ts.sample
+++ b/frontend/src/conf/app.config.ts.sample
@@ -44,5 +44,6 @@ export const AppConfig = {
       "nom_vern_eng",
       "cd_nom"
     ],
+    program_list_observers_names: true,
     program_list_sort: "-timestamp_create"
 }


### PR DESCRIPTION
Possibilité de ne pas afficher les noms d'observateurs dans la liste d'observation