### PR TITLE
backend/taxonomy: ForeignKey requires unique contraint

### DIFF
--- a/backend/gncitizen/core/taxonomy/models.py
+++ b/backend/gncitizen/core/taxonomy/models.py
@@ -10,7 +10,7 @@ class BibNoms(db.Model):
     __table_args__ = {"schema": "taxonomie", "extend_existing": True}
     id_nom = db.Column(db.Integer, primary_key=True)
     cd_nom = db.Column(db.Integer, nullable=True, unique=True)
-    cd_ref = db.Column(db.Integer)
+    cd_ref = db.Column(db.Integer, unique=True)
     nom_francais = db.Column(db.Unicode)
     comments = db.Column(db.Unicode)
 


### PR DESCRIPTION
le backend me donnait :

`sqlalchemy.exc.ProgrammingError: (psycopg2.errors.InvalidForeignKey) there is no unique constraint matching given keys for referenced table "bib_noms"`