### PR TITLE
frontend: add dependency to common.js

### DIFF
--- a/frontend/src/tsconfig.server.json
+++ b/frontend/src/tsconfig.server.json
@@ -2,7 +2,8 @@
     "extends": "./tsconfig.app.json",
     "compilerOptions": {
         "outDir": "../out-tsc/app-server",
-        "baseUrl": "."
+        "baseUrl": ".",
+        "module": "commonjs"
     },
     "angularCompilerOptions": {
         "entryModule": "app/app.server.module#AppServerModule"


### PR DESCRIPTION
le front me donnait :

 Error: Uncaught (in promise): TypeError: Cannot read property 'call' of undefined

```
appuser@5717bd8674e8:~/citizen/frontend$ ./start_server.sh
-------------------------------------------------
GeoNature-citizen frontend server is starting ...
-------------------------------------------------
Found '/home/appuser/citizen/frontend/.nvmrc' with version <v10.16>
Now using node v10.16.3 (npm v6.9.0)

> frontend@0.0.0 serve:ssr /home/appuser/citizen/frontend
> node dist/server

Node Express server listening on http://localhost:4000
ERROR { Error: Uncaught (in promise): TypeError: Cannot read property 'call' of undefined
TypeError: Cannot read property 'call' of undefined
    at __webpack_require__ (/home/appuser/citizen/frontend/dist/server.js:267924:30)
    at Function.requireEnsure [as e] (/home/appuser/citizen/frontend/dist/server.js:267943:25)
    at webpackAsyncContext (/home/appuser/citizen/frontend/dist/server.js:268597:29)
    at AppModule.<anonymous> (/home/appuser/citizen/frontend/dist/server.js:270149:165)
    at step (/home/appuser/citizen/frontend/dist/server.js:270130:23)
    at Object.next (/home/appuser/citizen/frontend/dist/server.js:270111:53)
    at /home/appuser/citizen/frontend/dist/server.js:270105:71
    at new ZoneAwarePromise (/home/appuser/citizen/frontend/dist/server.js:1105:33)
    at ./src/app/app.module.ts.__awaiter (/home/appuser/citizen/frontend/dist/server.js:270101:12)
    at AppModule../src/app/app.module.ts.AppModule.localeInitializer (/home/appuser/citizen/frontend/dist/server.js:270145:16)
    at resolvePromise (/home/appuser/citizen/frontend/dist/server.js:1026:35)
    at resolvePromise (/home/appuser/citizen/frontend/dist/server.js:985:21)
    at /home/appuser/citizen/frontend/dist/server.js:1087:21
    at ZoneDelegate.invokeTask (/home/appuser/citizen/frontend/dist/server.js:621:35)
    at Object.onInvokeTask (/home/appuser/citizen/frontend/dist/server.js:29363:33)
    at ZoneDelegate.invokeTask (/home/appuser/citizen/frontend/dist/server.js:620:40)
    at Zone.runTask (/home/appuser/citizen/frontend/dist/server.js:388:51)
    at drainMicroTaskQueue (/home/appuser/citizen/frontend/dist/server.js:801:39)
    at ZoneTask.invokeTask (/home/appuser/citizen/frontend/dist/server.js:707:25)
    at Server.ZoneTask.invoke (/home/appuser/citizen/frontend/dist/server.js:692:52)
  rejection:
   TypeError: Cannot read property 'call' of undefined
       at __webpack_require__ (/home/appuser/citizen/frontend/dist/server.js:267924:30)
       at Function.requireEnsure [as e] (/home/appuser/citizen/frontend/dist/server.js:267943:25)
       at webpackAsyncContext (/home/appuser/citizen/frontend/dist/server.js:268597:29)
       at AppModule.<anonymous> (/home/appuser/citizen/frontend/dist/server.js:270149:165)
       at step (/home/appuser/citizen/frontend/dist/server.js:270130:23)
       at Object.next (/home/appuser/citizen/frontend/dist/server.js:270111:53)
       at /home/appuser/citizen/frontend/dist/server.js:270105:71
       at new ZoneAwarePromise (/home/appuser/citizen/frontend/dist/server.js:1105:33)
       at ./src/app/app.module.ts.__awaiter (/home/appuser/citizen/frontend/dist/server.js:270101:12)
       at AppModule../src/app/app.module.ts.AppModule.localeInitializer (/home/appuser/citizen/frontend/dist/server.js:270145:16),
  promise:
   ZoneAwarePromise [Promise] {
     __zone_symbol__state: 0,
     __zone_symbol__value:
      TypeError: Cannot read property 'call' of undefined
          at __webpack_require__ (/home/appuser/citizen/frontend/dist/server.js:267924:30)
          at Function.requireEnsure [as e] (/home/appuser/citizen/frontend/dist/server.js:267943:25)
          at webpackAsyncContext (/home/appuser/citizen/frontend/dist/server.js:268597:29)
          at AppModule.<anonymous> (/home/appuser/citizen/frontend/dist/server.js:270149:165)
          at step (/home/appuser/citizen/frontend/dist/server.js:270130:23)
          at Object.next (/home/appuser/citizen/frontend/dist/server.js:270111:53)
          at /home/appuser/citizen/frontend/dist/server.js:270105:71
          at new ZoneAwarePromise (/home/appuser/citizen/frontend/dist/server.js:1105:33)
          at ./src/app/app.module.ts.__awaiter (/home/appuser/citizen/frontend/dist/server.js:270101:12)
          at AppModule../src/app/app.module.ts.AppModule.localeInitializer (/home/appuser/citizen/frontend/dist/server.js:270145:16) },
  zone:
   Zone {
     _parent:
      Zone {
        _parent: null,
        _name: '<root>',
        _properties: {},
        _zoneDelegate: [ZoneDelegate] },
     _name: 'angular',
     _properties: { isAngularZone: true },
     _zoneDelegate:
      ZoneDelegate {
        _taskCounts: [Object],
        zone: [Circular],
        _parentDelegate: [ZoneDelegate],
        _forkZS: null,
        _forkDlgt: null,
        _forkCurrZone: null,
        _interceptZS: null,
        _interceptDlgt: null,
        _interceptCurrZone: null,
        _invokeZS: [Object],
        _invokeDlgt: [ZoneDelegate],
        _invokeCurrZone: [Circular],
        _handleErrorZS: [Object],
        _handleErrorDlgt: [ZoneDelegate],
        _handleErrorCurrZone: [Circular],
        _scheduleTaskZS: [Object],
        _scheduleTaskDlgt: [ZoneDelegate],
        _scheduleTaskCurrZone: [Circular],
        _invokeTaskZS: [Object],
        _invokeTaskDlgt: [ZoneDelegate],
        _invokeTaskCurrZone: [Circular],
        _cancelTaskZS: [Object],
        _cancelTaskDlgt: [ZoneDelegate],
        _cancelTaskCurrZone: [Circular],
        _hasTaskZS: [Object],
        _hasTaskDlgt: [ZoneDelegate],
        _hasTaskDlgtOwner: [Circular],
        _hasTaskCurrZone: [Circular] } },
  task:
   ZoneTask {
     _zone:
      Zone {
        _parent: [Zone],
        _name: 'angular',
        _properties: [Object],
        _zoneDelegate: [ZoneDelegate] },
     runCount: 0,
     _zoneDelegates: null,
     _state: 'notScheduled',
     type: 'microTask',
     source: 'Promise.then',
     data:
      ZoneAwarePromise [Promise] {
        __zone_symbol__state: 0,
        __zone_symbol__value:
         TypeError: Cannot read property 'call' of undefined
             at __webpack_require__ (/home/appuser/citizen/frontend/dist/server.js:267924:30)
             at Function.requireEnsure [as e] (/home/appuser/citizen/frontend/dist/server.js:267943:25)
             at webpackAsyncContext (/home/appuser/citizen/frontend/dist/server.js:268597:29)
             at AppModule.<anonymous> (/home/appuser/citizen/frontend/dist/server.js:270149:165)
             at step (/home/appuser/citizen/frontend/dist/server.js:270130:23)
             at Object.next (/home/appuser/citizen/frontend/dist/server.js:270111:53)
             at /home/appuser/citizen/frontend/dist/server.js:270105:71
             at new ZoneAwarePromise (/home/appuser/citizen/frontend/dist/server.js:1105:33)
             at ./src/app/app.module.ts.__awaiter (/home/appuser/citizen/frontend/dist/server.js:270101:12)
             at AppModule../src/app/app.module.ts.AppModule.localeInitializer (/home/appuser/citizen/frontend/dist/server.js:270145:16) },
     scheduleFn: undefined,
     cancelFn: undefined,
     callback: [Function],
     invoke: [Function] } }
(node:65039) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
```

Solution copiée depuis https://github.com/angular/universal/issues/1169