### PR TITLE
Option pour activer Hcaptcha à l'inscription

### DIFF
--- a/backend/gncitizen/core/users/routes.py
+++ b/backend/gncitizen/core/users/routes.py
@@ -23,6 +23,7 @@ import smtplib
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 import base64
+import requests
 
 
 users_api = Blueprint("users", __name__)
@@ -72,6 +73,18 @@ def registration():
     """
     try:
         request_datas = dict(request.get_json())
+
+        if "HCAPTCHA_SECRET_KEY" in current_app.config and current_app.config["HCAPTCHA_SECRET_KEY"] is not None:
+            if not 'captchaToken' in request_datas or request_datas['captchaToken'] is None:
+                return ({"message": "Veuillez confirmer que vous êtes un humain."}, 400)
+
+            params = {'response': request_datas['captchaToken'], 'secret': current_app.config["HCAPTCHA_SECRET_KEY"]}
+            response = requests.post('https://hcaptcha.com/siteverify', data=params)
+            captchaResponse = response.json()
+
+            if not captchaResponse['success']:
+                return ({"message": "Captcha non valide."}, 400)
+
         datas_to_save = {}
         for data in request_datas:
             if hasattr(UserModel, data) and data != "password":

--- a/config/default_config.toml.template
+++ b/config/default_config.toml.template
@@ -25,6 +25,7 @@ CONFIRM_MAIL_SALT = 'your-secret-salt' # secret salt for corfirm mail token
 
 MEDIA_FOLDER = 'media'
 
+HCAPTCHA_SECRET_KEY=
 
 [RESET_PASSWD]
     SUBJECT = "Link"

--- a/frontend/src/app/auth/models.ts
+++ b/frontend/src/app/auth/models.ts
@@ -6,6 +6,7 @@ export class RegisterUser {
     surname?: string;
     avatar?: string | ArrayBuffer;
     extention?: string;
+    captchaToken?: string;
 
     constructor() {}
 }

--- a/frontend/src/app/auth/register/register.component.html
+++ b/frontend/src/app/auth/register/register.component.html
@@ -221,7 +221,7 @@
         </div>
         <div *ngIf="AppConfig.HCAPTCHA_SITE_KEY !== null" class="form-row">
             <div class="col-sm-12 text-center">
-                <div class="h-captcha" [attr.data-sitekey]="AppConfig.HCAPTCHA_SITE_KEY"></div>
+                <div id="h-captcha"></div>
             </div>
         </div>
 

--- a/frontend/src/app/auth/register/register.component.html
+++ b/frontend/src/app/auth/register/register.component.html
@@ -219,6 +219,11 @@
                 >
             </span>
         </div>
+        <div *ngIf="AppConfig.HCAPTCHA_SITE_KEY !== null" class="form-row">
+            <div class="col-sm-12 text-center">
+                <div class="h-captcha" [attr.data-sitekey]="AppConfig.HCAPTCHA_SITE_KEY"></div>
+            </div>
+        </div>
 
         <button
             *ngIf="errorMessage || !successMessage"

--- a/frontend/src/app/auth/register/register.component.ts
+++ b/frontend/src/app/auth/register/register.component.ts
@@ -162,4 +162,8 @@ export class RegisterComponent {
             callback: this.captchaCallback.bind(this),
         });
     }
+
+    captchaCallback(token) {
+        this.user.captchaToken = token;
+    }
 }

--- a/frontend/src/app/auth/register/register.component.ts
+++ b/frontend/src/app/auth/register/register.component.ts
@@ -29,7 +29,9 @@ export class RegisterComponent {
         private auth: AuthService,
         private router: Router,
         public activeModal: NgbActiveModal
-    ) {}
+    ) {
+        this.loadCaptchaScript(localeId);
+    }
 
     onRegister(): void {
         this.auth
@@ -37,7 +39,7 @@ export class RegisterComponent {
             .pipe(
                 map((user) => {
                     if (user) {
-                        let message = user.message;
+                        const message = user.message;
                         this._success.subscribe(
                             (message) => (this.successMessage = message)
                         );
@@ -96,8 +98,8 @@ export class RegisterComponent {
     onUploadAvatar($event) {
         if ($event) {
             if ($event.target.files && $event.target.files[0]) {
-                let reader = new FileReader();
-                let file = $event.target.files[0];
+                const reader = new FileReader();
+                const file = $event.target.files[0];
                 reader.readAsDataURL(file);
                 reader.onload = () => {
                     this.userAvatar = reader.result;
@@ -108,5 +110,16 @@ export class RegisterComponent {
                 };
             }
         }
+    }
+
+    loadCaptchaScript(locale) {
+        if (!AppConfig.HCAPTCHA_SITE_KEY) {
+            return;
+        }
+        const node = document.createElement('script');
+        node.src = 'https://hcaptcha.com/1/api.js?hl=' + locale;
+        node.type = 'text/javascript';
+        node.async = true;
+        document.getElementsByTagName('head')[0].appendChild(node);
     }
 }

--- a/frontend/src/app/auth/register/register.component.ts
+++ b/frontend/src/app/auth/register/register.component.ts
@@ -52,9 +52,10 @@ export class RegisterComponent {
                 map((user) => {
                     if (user) {
                         const message = user.message;
-                        this._success.subscribe(
-                            (message) => (this.successMessage = message)
-                        );
+                        this._success.subscribe((message) => {
+                            this.errorMessage = null;
+                            return (this.successMessage = message);
+                        });
                         this._success.pipe(debounceTime(5000)).subscribe(() => {
                             this.successMessage = null;
                             this.activeModal.close();

--- a/frontend/src/conf/app.config.ts.template
+++ b/frontend/src/conf/app.config.ts.template
@@ -2,6 +2,7 @@ export const AppConfig = {
     appName: "GeoNature-citizen",
     API_ENDPOINT:"http://localhost:5002/api",
     API_TAXHUB:"http://localhost:5000/api",
+    HCAPTCHA_SITE_KEY: null,
     FRONTEND:{
         PROD_MOD:true,
         MULTILINGUAL:false,


### PR DESCRIPTION
Ces modifications permettent d'ajouter un captcha (hCatpcha) dans le formulaire d'inscription, seulement si les variables globales sont définies.

**Principales modifications:**
- Ajout du script hcaptcha et rendu du captcha après l'initialisation du formulaire d'inscription, si la variable `HCAPTCHA_SITE_KEY` est définie
- Ajout d'un champs captchaToken dans le modèle `RegisterUser` pour envoyer le token à l'API
- Vérification du token dans l'API, si la variable `HCAPTCHA_SECRET_KEY` est définie