### PR TITLE
Vérification de l'utilisateur par envoi d'email optionnel

### DIFF
--- a/backend/gncitizen/core/users/routes.py
+++ b/backend/gncitizen/core/users/routes.py
@@ -145,19 +145,19 @@ def registration():
             handler.close()
 
 
-
-        if current_app.config["CONFIRM_EMAIL"]["USE_CONFIRM_EMAIL"] == False:
-            message = """Félicitations, l'utilisateur "{}" a été créé.""".format(
-                newuser.username
-            ),
-        else:
-            message = """Félicitations, l'utilisateur "{}" a été créé.  \r\n Vous allez recevoir un email pour activer votre compte """.format(
-                newuser.username
-            ),
-            try:
+        try:
+            if current_app.config["CONFIRM_EMAIL"]["USE_CONFIRM_EMAIL"] == False:
+                message = """Félicitations, l'utilisateur "{}" a été créé.""".format(
+                    newuser.username
+                ),
+                confirm_user_email(newuser, with_confirm_link=False)
+            else:
+                message = """Félicitations, l'utilisateur "{}" a été créé.  \r\n Vous allez recevoir un email pour activer votre compte """.format(
+                    newuser.username
+                ),
                 confirm_user_email(newuser)
-            except Exception as e:
-                return {"message mail faild": str(e)}, 500
+        except Exception as e:
+            return {"message mail faild": str(e)}, 500
 
         # send confirm mail
         return (

--- a/backend/gncitizen/utils/mail_check.py
+++ b/backend/gncitizen/utils/mail_check.py
@@ -5,7 +5,7 @@ from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 
 
-def confirm_user_email(newuser):
+def confirm_user_email(newuser, with_confirm_link = True):
 
     token = generate_confirmation_token(newuser.email)
     msg = MIMEMultipart("alternative")
@@ -21,9 +21,13 @@ def confirm_user_email(newuser):
         url_application = url_application + "/"
     print("url_application", url_application)
     activate_url = url_application + "confirmEmail/" + token
+
     # Record the MIME  text/html.
+    template = current_app.config["CONFIRM_EMAIL"]["HTML_TEMPLATE"]
+    if not with_confirm_link:
+        template = current_app.config["CONFIRM_EMAIL"]["NO_VALIDATION_HTML_TEMPLATE"]
     msg_body = MIMEText(
-        current_app.config["CONFIRM_EMAIL"]["HTML_TEMPLATE"].format(
+        template.format(
             activate_url=activate_url
         ),
         "html",

--- a/config/default_config.toml.template
+++ b/config/default_config.toml.template
@@ -40,6 +40,7 @@ MEDIA_FOLDER = 'media'
     '''
 
 [CONFIRM_EMAIL]
+    USE_CONFIRM_EMAIL = true
     SUBJECT = "Activez votre compte"
     FROM = 'contact@geonature-citizen.fr'
     HTML_TEMPLATE = '''<p> Bonjour,</p><br /><p>Nous vous confirmons que votre compte a bien été créé.</p>

--- a/config/default_config.toml.template
+++ b/config/default_config.toml.template
@@ -48,6 +48,10 @@ MEDIA_FOLDER = 'media'
      <p>Nous vous souhaitons la bienvenue sur notre site.</p><br />
      <p>Bien à vous.</p>
     '''
+    NO_VALIDATION_HTML_TEMPLATE = '''<p> Bonjour,</p><br /><p>Nous vous confirmons que votre compte a bien été créé.</p>
+     <p>Nous vous souhaitons la bienvenue sur notre site.</p><br />
+     <p>Bien à vous.</p>
+    '''
 
 [MAIL]
     MAIL_USE_SSL = false


### PR DESCRIPTION
J'aimerais savoir si cette modification vous intéresse et que je fais une PR sur ce repo ou si je la garde en spécifique ?

**Principales modifications:**
- Ajout d'un paramètre global `USE_CONFIRM_EMAIL`
- Si `USE_CONFIRM_EMAIL` est défini sur `False`, l'utilisateur est activé par défaut à l'inscription
- Si `USE_CONFIRM_EMAIL` est défini sur `False`, aucun n'email de vérification n'est envoyé à l'inscription