### PR TITLE
Connexion avec email ou pseudo

### DIFF
--- a/frontend/src/app/auth/login/login.component.html
+++ b/frontend/src/app/auth/login/login.component.html
@@ -72,7 +72,7 @@
         (ngSubmit)="loginForm.form.valid && onLogin()"
     >
         <div class="form-group">
-            <label for="email" i18n="email input label@@emailInputLabel">Email</label>
+            <label for="email" i18n="email or username@@emailOrUsernameInputLabel">Email ou pseudo</label>
             <div class="input-group">
                 <div class="input-group-prepend">
                     <span
@@ -87,7 +87,7 @@
                     type="email"
                     class="form-control rounded-0"
                     id="email"
-                    placeholder="Entrez votre adresse mail"
+                    placeholder="Entrez votre adresse mail ou pseudo"
                     aria-label="Email"
                     aria-describedby="emailInput"
                     i18n-placeholder="emailInput@@emailInput"

--- a/frontend/src/i18n/messages.en.xlf
+++ b/frontend/src/i18n/messages.en.xlf
@@ -466,8 +466,8 @@
         </context-group>
         <note priority="1" from="description">Recover account</note>
       </trans-unit>
-      <trans-unit id="emailInputLabel" datatype="html">
-        <source>Email</source><target state="new">Email</target>
+      <trans-unit id="emailOrUsernameInputLabel" datatype="html">
+        <source>Email ou pseudo</source><target state="new">Email or username</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/auth/login/login.component.html</context>
           <context context-type="linenumber">76</context>
@@ -879,7 +879,7 @@
         </context-group>
         <note priority="1" from="description">Carousel previous</note>
       </trans-unit>
-      
+
       <trans-unit id="ngbCarouselNext" datatype="html">
         <source>Prochain</source><target state="new">Next</target>
         <context-group purpose="location">

--- a/frontend/src/i18n/messages.fr.xlf
+++ b/frontend/src/i18n/messages.fr.xlf
@@ -466,8 +466,8 @@
         </context-group>
         <note priority="1" from="description">Recover account</note>
       </trans-unit>
-      <trans-unit id="emailInputLabel" datatype="html">
-        <source>Email</source><target state="final">Email</target>
+      <trans-unit id="emailOrUsernameInputLabel" datatype="html">
+        <source>Email ou pseudo</source><target state="final">Email ou pseudo</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/auth/login/login.component.html</context>
           <context context-type="linenumber">76</context>
@@ -879,7 +879,7 @@
         </context-group>
         <note priority="1" from="description">Carousel previous</note>
       </trans-unit>
-      
+
       <trans-unit id="ngbCarouselNext" datatype="html">
         <source>Prochain</source><target state="final">Prochain</target>
         <context-group purpose="location">

--- a/frontend/src/i18n/messages.xlf
+++ b/frontend/src/i18n/messages.xlf
@@ -454,8 +454,8 @@
         </context-group>
         <note priority="1" from="description">Recover account</note>
       </trans-unit>
-      <trans-unit id="emailInputLabel" datatype="html">
-        <source>Email</source>
+      <trans-unit id="emailOrUsernameInputLabel" datatype="html">
+        <source>Email ou pseudo</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/auth/login/login.component.html</context>
           <context context-type="linenumber">76</context>


### PR DESCRIPTION
Cela permet à l'utilisateur de se connecter soit en saisissant son email, soit son pseudo pour se connecter à la plateforme. (toujours en plus de son mot de passe)

**Principales modification:**
- Récupération de l'utilisateur par son email ou son pseudo à la connexion coté API (`or_(UserModel.email == email, UserModel.username == email)`)
- Mise à jour des label et placeholder dans le formulaire de connexion