### PR TITLE
feat(admin): Add Observations section

### DIFF
--- a/backend/gncitizen/core/commons/admin.py
+++ b/backend/gncitizen/core/commons/admin.py
@@ -139,3 +139,6 @@ class GeometryView(ModelView):
         flash("Une erreur s'est produite ({})".format(exc), "error")
         return True
 
+class ObservationView(ModelView):
+    create_template = "edit.html"
+    edit_template = "edit.html"

--- a/backend/gncitizen/core/commons/routes.py
+++ b/backend/gncitizen/core/commons/routes.py
@@ -36,6 +36,7 @@ from gncitizen.core.commons.admin import (
     CustomFormView,
     UserView,
     GeometryView,
+    ObservationView
 )
 from gncitizen.core.sites.models import CorProgramSiteTypeModel, SiteTypeModel
 from gncitizen.core.sites.admin import SiteTypeView
@@ -43,6 +44,10 @@ from gncitizen.utils.env import MEDIA_DIR
 
 commons_api = Blueprint("commons", __name__)
 
+
+admin.add_view(
+    ObservationView(ObservationModel, db.session, "Observations")
+)
 
 admin.add_view(UserView(UserModel, db.session, "Utilisateurs"))
 admin.add_view(


### PR DESCRIPTION
Enables the admin to delete or change Observations within the backoffice (FlaskAdmin) page. Like Users and Projects.

Here is the result:
![image](https://user-images.githubusercontent.com/85738261/124740418-138c3980-df1b-11eb-8dfd-8335d51cfbc6.png)

Closes #284 