### PR TITLE
fix(email): corrected reset password function

### DIFF
--- a/backend/gncitizen/core/users/routes.py
+++ b/backend/gncitizen/core/users/routes.py
@@ -506,7 +506,7 @@ def reset_user_password():
                 str(current_app.config["MAIL"]["MAIL_AUTH_PASSWD"]),
             )
             server.sendmail(
-                current_app.config["MAIL"]["MAIL_FROM"], user.email, msg.as_string()
+                current_app.config["RESET_PASSWD"]["FROM"], user.email, msg.as_string()
             )
             server.quit()
         user.password = passwd_hash


### PR DESCRIPTION
The reset password function called a key that did not exist in the configuration (toml file). Now calls the FROM key in the RESET_PASSWD section of the configuration.

Closes #287 