### PR TITLE
Ne pas renvoyer une erreur 404 depuis l'API si la réponse est une liste vide

### DIFF
--- a/backend/gncitizen/utils/sqlalchemy.py
+++ b/backend/gncitizen/utils/sqlalchemy.py
@@ -195,7 +195,7 @@ def json_resp(fn):
 
 
 def to_json_resp(res, status=200, filename=None, as_file=False, indent=None):
-    if not res:
+    if not res and not isinstance(res, list):
         status = 404
         res = {"message": "not found"}
 


### PR DESCRIPTION
Bonjour / Bonsoir !
J'ai constaté avec un nouveau développement que si la réponse de l'API est une liste vide (car aucune ligne n'est présente dans une table dans la base par exemple), j'ai une erreur 404 qui est renvoyée.
Dans ce cas, j'ai donc une erreur affichée sur le front me disant qu'une erreur est survenue lors de la récupération des données sur le serveur.

Je pourrais faire un développement supplémentaire comme c'est le cas pour la liste des programmes, mais le code 404 étant pour une page ou une route introuvable, je trouve plus pertinent de renvoyer une liste vide qu'une erreur.
J'ai donc simplement ajouter une vérification dans la fonction `to_json_resp` pour ne pas renvoyer `{"message": "not found"}` si la variable`res` est une liste vide.

Je me demande si c'est volontaire ou non? Et si c'est volontaire, pour quelles routes cela est-il important ?