### PR TITLE
fix: fix l'erreur de vignette lorsque les premiers médias ne sont pas des images 

### DIFF
--- a/backend/gncitizen/core/observations/routes.py
+++ b/backend/gncitizen/core/observations/routes.py
@@ -326,110 +326,110 @@ def post_observation():
         return {"message": str(e)}, 400
 
 
-@obstax_api.route("/observations", methods=["GET"])
-@json_resp
-def get_observations():
-    """Get all observations
-        ---
-        tags:
-          - observations
-        definitions:
-          cd_nom:
-            type: integer
-            description: cd_nom taxref
-          geometry:
-            type: dict
-            description: Géométrie de la donnée
-          name:
-            type: string
-          geom:
-            type: geometry
-        responses:
-          200:
-            description: A list of all observations
-        """
-    try:
-        observations = ObservationModel.query.order_by(
-            desc(ObservationModel.timestamp_create)
-        ).all()
-        features = []
-        for observation in observations:
-            feature = get_geojson_feature(observation.geom)
-            observation_dict = observation.as_dict(True)
-            for k in observation_dict:
-                if k in obs_keys:
-                    feature["properties"][k] = observation_dict[k]
+# @obstax_api.route("/observations", methods=["GET"])
+# @json_resp
+# def get_observations():
+#     """Get all observations
+#         ---
+#         tags:
+#           - observations
+#         definitions:
+#           cd_nom:
+#             type: integer
+#             description: cd_nom taxref
+#           geometry:
+#             type: dict
+#             description: Géométrie de la donnée
+#           name:
+#             type: string
+#           geom:
+#             type: geometry
+#         responses:
+#           200:
+#             description: A list of all observations
+#         """
+#     try:
+#         observations = ObservationModel.query.order_by(
+#             desc(ObservationModel.timestamp_create)
+#         ).all()
+#         features = []
+#         for observation in observations:
+#             feature = get_geojson_feature(observation.geom)
+#             observation_dict = observation.as_dict(True)
+#             for k in observation_dict:
+#                 if k in obs_keys:
+#                     feature["properties"][k] = observation_dict[k]
 
-            taxref = get_specie_from_cd_nom(feature["properties"]["cd_nom"])
-            for k in taxref:
-                feature["properties"][k] = taxref[k]
-            features.append(feature)
-        return FeatureCollection(features)
-    except Exception as e:
-        current_app.logger.critical("[get_observations] Error: %s", str(e))
-        return {"message": str(e)}, 400
+#             taxref = get_specie_from_cd_nom(feature["properties"]["cd_nom"])
+#             for k in taxref:
+#                 feature["properties"][k] = taxref[k]
+#             features.append(feature)
+#         return FeatureCollection(features)
+#     except Exception as e:
+#         current_app.logger.critical("[get_observations] Error: %s", str(e))
+#         return {"message": str(e)}, 400
 
 
-@obstax_api.route("/observations/lists/<int:id>", methods=["GET"])
-@json_resp
-def get_observations_from_list(id):  # noqa: A002
-    """Get all observations from a taxonomy list
-    GET
-        ---
-        tags:
-          - observations
-        parameters:
-          - name: id
-            in: path
-            type: integer
-            required: true
-            example: 1
-        definitions:
-          cd_nom:
-            type: integer
-            description: cd_nom taxref
-          geometry:
-            type: dict
-            description: Géométrie de la donnée
-          name:
-            type: string
-          geom:
-            type: geometry
-        responses:
-          200:
-            description: A list of all species lists
-        """
-    # taxhub_url = load_config()['TAXHUB_API_URL']
-    taxhub_lists_taxa_url = taxhub_lists_url + "taxons/" + str(id)
-    rtaxa = requests.get(taxhub_lists_taxa_url)
-    if rtaxa.status_code == 200:
-        try:
-            taxa = rtaxa.json()["items"]
-            current_app.logger.debug(taxa)
-            features = []
-            for t in taxa:
-                current_app.logger.debug("R", t["cd_nom"])
-                datas = (
-                    ObservationModel.query.filter_by(cd_nom=t["cd_nom"])
-                    .order_by(desc(ObservationModel.timestamp_create))
-                    .all()
-                )
-                for d in datas:
-                    feature = get_geojson_feature(d.geom)
-                    observation_dict = d.as_dict(True)
-                    for k in observation_dict:
-                        if k in obs_keys:
-                            feature["properties"][k] = observation_dict[k]
-                    taxref = get_specie_from_cd_nom(feature["properties"]["cd_nom"])
-                    for k in taxref:
-                        feature["properties"][k] = taxref[k]
-                    features.append(feature)
-            return FeatureCollection(features)
-        except Exception as e:
-            current_app.logger.critical(
-                "[get_observations_from_list] Error: %s", str(e)
-            )
-            return {"message": str(e)}, 400
+# @obstax_api.route("/observations/lists/<int:id>", methods=["GET"])
+# @json_resp
+# def get_observations_from_list(id):  # noqa: A002
+#     """Get all observations from a taxonomy list
+#     GET
+#         ---
+#         tags:
+#           - observations
+#         parameters:
+#           - name: id
+#             in: path
+#             type: integer
+#             required: true
+#             example: 1
+#         definitions:
+#           cd_nom:
+#             type: integer
+#             description: cd_nom taxref
+#           geometry:
+#             type: dict
+#             description: Géométrie de la donnée
+#           name:
+#             type: string
+#           geom:
+#             type: geometry
+#         responses:
+#           200:
+#             description: A list of all species lists
+#         """
+#     # taxhub_url = load_config()['TAXHUB_API_URL']
+#     taxhub_lists_taxa_url = taxhub_lists_url + "taxons/" + str(id)
+#     rtaxa = requests.get(taxhub_lists_taxa_url)
+#     if rtaxa.status_code == 200:
+#         try:
+#             taxa = rtaxa.json()["items"]
+#             current_app.logger.debug(taxa)
+#             features = []
+#             for t in taxa:
+#                 current_app.logger.debug("R", t["cd_nom"])
+#                 datas = (
+#                     ObservationModel.query.filter_by(cd_nom=t["cd_nom"])
+#                     .order_by(desc(ObservationModel.timestamp_create))
+#                     .all()
+#                 )
+#                 for d in datas:
+#                     feature = get_geojson_feature(d.geom)
+#                     observation_dict = d.as_dict(True)
+#                     for k in observation_dict:
+#                         if k in obs_keys:
+#                             feature["properties"][k] = observation_dict[k]
+#                     taxref = get_specie_from_cd_nom(feature["properties"]["cd_nom"])
+#                     for k in taxref:
+#                         feature["properties"][k] = taxref[k]
+#                     features.append(feature)
+#             return FeatureCollection(features)
+#         except Exception as e:
+#             current_app.logger.critical(
+#                 "[get_observations_from_list] Error: %s", str(e)
+#             )
+#             return {"message": str(e)}, 400
 
 
 @obstax_api.route("/programs/<int:program_id>/observations", methods=["GET"])
@@ -539,32 +539,32 @@ def get_program_observations(
                     feature["properties"][k] = observation_dict[k]
 
             # TaxRef
-            if current_app.config.get("API_TAXHUB") is None:
-                taxref = Taxref.query.filter(
-                    Taxref.cd_nom == observation.ObservationModel.cd_nom
-                ).first()
-                if taxref:
-                    feature["properties"]["taxref"] = taxref.as_dict(True)
+            # if current_app.config.get("API_TAXHUB") is None:
+            #     taxref = Taxref.query.filter(
+            #         Taxref.cd_nom == observation.ObservationModel.cd_nom
+            #     ).first()
+            #     if taxref:
+            #         feature["properties"]["taxref"] = taxref.as_dict(True)
 
-                medias = TMedias.query.filter(
-                    TMedias.cd_ref == observation.ObservationModel.cd_nom
-                ).all()
-                if medias:
-                    feature["properties"]["medias"] = [
-                        media.as_dict(True) for media in medias
-                    ]
-            else:
-                try:
-                    taxon = next(
-                        taxon
-                        for taxon in taxon_repository
-                        if taxon and taxon["cd_nom"] == feature["properties"]["cd_nom"]
-                    )
-                    feature["properties"]["nom_francais"] = taxon["nom_francais"]
-                    feature["properties"]["taxref"] = taxon["taxref"]
-                    feature["properties"]["medias"] = taxon["medias"]
-                except StopIteration:
-                    pass
+            #     medias = TMedias.query.filter(
+            #         TMedias.cd_ref == observation.ObservationModel.cd_nom
+            #     ).all()
+            #     if medias:
+            #         feature["properties"]["medias"] = [
+            #             media.as_dict(True) for media in medias
+            #         ]
+            # else:
+            try:
+                taxon = next(
+                    taxon
+                    for taxon in taxon_repository
+                    if taxon and taxon["cd_nom"] == feature["properties"]["cd_nom"]
+                )
+                feature["properties"]["nom_francais"] = taxon["nom_francais"]
+                feature["properties"]["taxref"] = taxon["taxref"]
+                feature["properties"]["medias"] = taxon["medias"]
+            except StopIteration:
+                pass
             features.append(feature)
 
         return FeatureCollection(features)

--- a/frontend/src/conf/map.config.ts.template
+++ b/frontend/src/conf/map.config.ts.template
@@ -1,92 +1,86 @@
 export const MAP_CONFIG = {
-  DEFAULT_PROVIDER: "OpenStreetMapOrg",
-  BASEMAPS: [
-    {
-      name: "OpenStreetMapOrg",
-      maxZoom: 19,
-      layer: "//{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
-      subdomains: "abc",
-      attribution:
-        '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, Tiles style by <a href="https://www.hotosm.org/" target="_blank">Humanitarian OpenStreetMap Team</a> hosted by <a href="https://openstreetmap.fr/" target="_blank">OpenStreetMap France</a>'
-    },
-    // {
-    //   name: "OpenStreetMapFRHot",
-    //   maxZoom: 19,
-    //   layer: "//{s}.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png",
-    //   subdomains: "abc",
-    //   attribution:
-    //     '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, Tiles style by <a href="https://www.hotosm.org/" target="_blank">Humanitarian OpenStreetMap Team</a> hosted by <a href="https://openstreetmap.fr/" target="_blank">OpenStreetMap France</a>'
-    // },
-    // {
-    //   name: "OpenStreetMapCH",
-    //   maxZoom: 18,
-    //   layer: "//tile.osm.ch/switzerland/{z}/{x}/{y}.png",
-    //   subdomains: "abc",
-    //   attribution:
-    //     '&copy; <a href="&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
-    //   bounds: [[45, 5], [48, 11]]
-    // },
-    // {
-    //   name: "OpenStreetMapDE",
-    //   maxZoom: 18,
-    //   layer: "//{s}.tile.openstreetmap.de/tiles/osmde/{z}/{x}/{y}.png",
-    //   subdomains: "abc",
-    //   attribution:
-    //     '&copy; <a href="&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
-    // },
-    // {
-    //   name: "OpenStreetMapBZH",
-    //   maxZoom: 18,
-    //   layer: "//tile.openstreetmap.bzh/br/{z}/{x}/{y}.png",
-    //   subdomains: "",
-    //   attribution:
-    //     '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, Tiles courtesy of <a href="http://www.openstreetmap.bzh/" target="_blank">Breton OpenStreetMap Team</a>',
-    //   bounds: [[46.2, -5.5], [50, 0.7]]
-    // },
-    {
-      name: "OpenTopoMap",
-      maxZoom: 17,
-      layer: "//{s}.opentopomap.org/{z}/{x}/{y}.png",
-      subdomains: "abc",
-      attribution: "© OpenTopoMap"
-    },
-    {
-      name: "IGN Vue satellite",
-      maxZoom: 17,
-      layer: "https://wxs.ign.fr/{apiKey}/geoportail/wmts?&REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE=normal&TILEMATRIXSET=PM&FORMAT=image/jpeg&LAYER={layerName}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
-      layerName: "ORTHOIMAGERY.ORTHOPHOTOS",
-      // Remplacer "pratique" par votre clé IGN
-      apiKey: 'pratique',
-      subdomains: "abc",
-      attribution: "© IGN-F/Geoportail"
-    },
-    {
-      name: "IGN Cartes",
-      maxZoom: 17,
-      layer: "https://wxs.ign.fr/{apiKey}/geoportail/wmts?&REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE=normal&TILEMATRIXSET=PM&FORMAT=image/jpeg&LAYER={layerName}&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}",
-      layerName: "GEOGRAPHICALGRIDSYSTEMS.MAPS",
-      // Remplacer "pratique" par votre clé IGN
-      apiKey: 'pratique',
-      subdomains: "abc",
-      attribution: "© IGN-F/Geoportail"
-    },
-    // {
-    //   // ⚠ google's terms&conditions
-    //   // https://github.com/Leaflet/Leaflet/blob/master/FAQ.md#i-want-to-use-google-maps-api-tiles-with-leaflet-can-i-do-that
-    //   name: "GoogleSatellite",
-    //   maxZoom: 20,
-    //   layer: "//mt{s}.google.com/vt/lyrs=s&x={x}&y={y}&z={z}",
-    //   subdomains: "1",
-    //   attribution: "© GoogleMap"
-    // }
-  ],
-  CENTER: [46.52863469527167, 2.43896484375],
-  ZOOM_LEVEL: 6,
-  ZOOM_LEVEL_RELEVE: 15,
-  NEW_OBS_POINTER: "assets/pointer-blue2.png",
-  OBS_POINTER: "assets/pointer-green.png",
+    DEFAULT_PROVIDER: 'OpenStreetMapOrg',
+    BASEMAPS: [
+        {
+            name: 'OpenStreetMapOrg',
+            maxZoom: 19,
+            layer: '//{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+            subdomains: 'abc',
+            attribution:
+                '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, Tiles style by <a href="https://www.hotosm.org/" target="_blank">Humanitarian OpenStreetMap Team</a> hosted by <a href="https://openstreetmap.fr/" target="_blank">OpenStreetMap France</a>',
+        },
+        // {
+        //   name: "OpenStreetMapFRHot",
+        //   maxZoom: 19,
+        //   layer: "//{s}.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png",
+        //   subdomains: "abc",
+        //   attribution:
+        //     '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, Tiles style by <a href="https://www.hotosm.org/" target="_blank">Humanitarian OpenStreetMap Team</a> hosted by <a href="https://openstreetmap.fr/" target="_blank">OpenStreetMap France</a>'
+        // },
+        // {
+        //   name: "OpenStreetMapCH",
+        //   maxZoom: 18,
+        //   layer: "//tile.osm.ch/switzerland/{z}/{x}/{y}.png",
+        //   subdomains: "abc",
+        //   attribution:
+        //     '&copy; <a href="&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+        //   bounds: [[45, 5], [48, 11]]
+        // },
+        // {
+        //   name: "OpenStreetMapDE",
+        //   maxZoom: 18,
+        //   layer: "//{s}.tile.openstreetmap.de/tiles/osmde/{z}/{x}/{y}.png",
+        //   subdomains: "abc",
+        //   attribution:
+        //     '&copy; <a href="&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+        // },
+        // {
+        //   name: "OpenStreetMapBZH",
+        //   maxZoom: 18,
+        //   layer: "//tile.openstreetmap.bzh/br/{z}/{x}/{y}.png",
+        //   subdomains: "",
+        //   attribution:
+        //     '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, Tiles courtesy of <a href="http://www.openstreetmap.bzh/" target="_blank">Breton OpenStreetMap Team</a>',
+        //   bounds: [[46.2, -5.5], [50, 0.7]]
+        // },
+        {
+            name: 'OpenTopoMap',
+            maxZoom: 17,
+            layer: '//{s}.opentopomap.org/{z}/{x}/{y}.png',
+            subdomains: 'abc',
+            attribution: '© OpenTopoMap',
+        },
+        {
+            name: 'IGN Vue satellite',
+            maxZoom: 19,
+            layer: 'https://wxs.ign.fr/decouverte/geoportail/wmts?&REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&TILEMATRIXSET=PM&LAYER=ORTHOIMAGERY.ORTHOPHOTOS&STYLE=normal&FORMAT=image/jpeg&TILECOL={x}&TILEROW={y}&TILEMATRIX={z}',
+            subdomains: 'abc',
+            attribution: '© IGN-F/Geoportail',
+        },
+        {
+            name: 'IGN Cartes',
+            maxZoom: 19,
+            layer: 'https://wxs.ign.fr/decouverte/geoportail/wmts?&REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&TILEMATRIXSET=PM&LAYER=GEOGRAPHICALGRIDSYSTEMS.PLANIGNV2&STYLE=normal&FORMAT=image/png&TILECOL={x}&TILEROW={y}&TILEMATRIX={z}',
+            subdomains: 'abc',
+            attribution: '© IGN-F/Geoportail',
+        },
+        // {
+        //   // ⚠ google's terms&conditions
+        //   // https://github.com/Leaflet/Leaflet/blob/master/FAQ.md#i-want-to-use-google-maps-api-tiles-with-leaflet-can-i-do-that
+        //   name: "GoogleSatellite",
+        //   maxZoom: 20,
+        //   layer: "//mt{s}.google.com/vt/lyrs=s&x={x}&y={y}&z={z}",
+        //   subdomains: "1",
+        //   attribution: "© GoogleMap"
+        // }
+    ],
+    CENTER: [46.52863469527167, 2.43896484375],
+    ZOOM_LEVEL: 6,
+    ZOOM_LEVEL_RELEVE: 15,
+    NEW_OBS_POINTER: 'assets/pointer-blue2.png',
+    OBS_POINTER: 'assets/pointer-green.png',
     LOCATE_CONTROL_TITLE: {
-    'fr':'Me localiser',
-    'en':'Show me where i am'
-  }
-}
+        fr: 'Me localiser',
+        en: 'Show me where i am',
+    },
+};


### PR DESCRIPTION
fix #291 : Les médias dorénavant  utilisés pour illustrer les taxons doivent être des photos. 3 types de médias peuvent être utilisés, par ordre de priorité décroissant:

- Photo_gncitizen (type à ajouter à TaxHub si utilisé)
- Photo_principale 
- Photo.

Le taxon sera illustré par le premier média répondant à ce critère.

Autre nouveauté, l'intégration des nouvelles couches publiques de l'IGN (plan v2 et orthophoto).

Début de nettoyage des dépendances au schéma taxonomie,