### PR TITLE
fix #286: node server not managed (stop and restart) by supervisor

### DIFF
--- a/install/supervisor/gncitizen_frontssr-service.conf
+++ b/install/supervisor/gncitizen_frontssr-service.conf
@@ -6,3 +6,5 @@ autostart=true
 autorestart=true
 stdout_logfile = APP_PATH/var/log/supervisor_gncitizen_front.log
 redirect_stderr = true
+stopasgroup=true
+stopsignal=QUIT


### PR DESCRIPTION
fix #286 