### PR TITLE
fix visit date in site form

### DIFF
--- a/frontend/src/app/programs/sites/form/form.component.ts
+++ b/frontend/src/app/programs/sites/form/form.component.ts
@@ -186,7 +186,7 @@ export class SiteVisitFormComponent implements OnInit, AfterViewInit {
         const visitDate = NgbDate.from(this.visitForm.controls.date.value);
         this.visitForm.patchValue({
             data: this.getTotalJsonData(),
-            date: new Date(visitDate.year, visitDate.month, visitDate.day)
+            date: new Date(visitDate.year, visitDate.month - 1, visitDate.day, 12)
                 .toISOString()
                 .match(/\d{4}-\d{2}-\d{2}/)[0],
         });


### PR DESCRIPTION
Hello, 

I fixed a bug in the form for submitting the visits to a site. 

The date was wrongly encoded in the js form:

-  the month was expressed from 1 to 12 (coming from `month: this.today.getMonth() + 1,` in L43 of frontend/src/app/programs/sites/form/form.component.ts and the Date was built based on this month. However, a Date js object has month expressed from 0 to 11. It was resulting that the date stored in the DB was one month later.
- the day was wrong as well, because the Date object is converted to ISOString. But since the hour was not set, the new Date object assume a hour of 00, which was translated to "day - 1, 22h" due to the locale of my computer. I fixed it (not perfectly) by setting a arbitrary hour of 12 (middle of the day). 
 
```
let d = new Date(2021, 09, 20).toISOString();
     '2021-10-19T22:00:00.000Z'
let d = new Date(2021, 09, 20, 12).toISOString();
    '2021-10-20T10:00:00.000Z'

````