### PR TITLE
correct program link in home page for mobile

### DIFF
--- a/frontend/src/app/home/home.component.html
+++ b/frontend/src/app/home/home.component.html
@@ -152,7 +152,7 @@
                                 [routerLink]="[
                                     '/programs',
                                     p.id_program,
-                                    'observations'
+                                    p.module.name
                                 ]"
                                 >{{
                                     AppConfig.platform_participate[localeId]


### PR DESCRIPTION
In mobile, the link to the programs modal in the home page was always directing to the "observations" programs, and not to the "sites" program in case the program was of type "sites".