### PR TITLE
Redimensionnement et compression de l'avatar avant upload

### DIFF
--- a/frontend/src/app/auth/register/register.component.ts
+++ b/frontend/src/app/auth/register/register.component.ts
@@ -112,16 +112,49 @@ export class RegisterComponent {
     onUploadAvatar($event) {
         if ($event) {
             if ($event.target.files && $event.target.files[0]) {
-                const reader = new FileReader();
                 const file = $event.target.files[0];
-                reader.readAsDataURL(file);
-                reader.onload = () => {
-                    this.userAvatar = reader.result;
-                    this.user.avatar = this.userAvatar;
-                    this.user.extention = $event.target.files[0].type
-                        .split('/')
-                        .pop();
+                const img = document.createElement('img');
+                img.onload = (event) => {
+                    let newImage = null;
+                    if (event.target) {
+                        newImage = event.target;
+                    } else if (!event['path'] || !event['path'].length) {
+                        newImage = event['path'][0];
+                    }
+                    if (!newImage) {
+                        console.error('No image found on this navigator');
+                        return;
+                    }
+                    const canvas = document.createElement('canvas');
+                    const ctx = canvas.getContext('2d');
+
+                    let resizeTimeNumber = 1;
+                    const maxHeightRatio =
+                        newImage.height / AppConfig.imageUpload.maxHeight;
+                    if (maxHeightRatio > 1) {
+                        resizeTimeNumber = maxHeightRatio;
+                    }
+                    const maxWidthRatio =
+                        newImage.width / AppConfig.imageUpload.maxWidth;
+                    if (maxWidthRatio > 1 && maxWidthRatio > maxHeightRatio) {
+                        resizeTimeNumber = maxWidthRatio;
+                    }
+
+                    canvas.width = newImage.width / resizeTimeNumber;
+                    canvas.height = newImage.height / resizeTimeNumber;
+
+                    ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+
+                    const resizedImage = canvas.toDataURL(
+                        'image/jpeg',
+                        AppConfig.imageUpload.quality
+                    );
+
+                    this.userAvatar = resizedImage;
+                    this.user.avatar = resizedImage;
+                    this.user.extention = 'jpeg';
                 };
+                img.src = window.URL.createObjectURL(file);
             }
         }
     }

--- a/frontend/src/app/auth/user-dashboard/user-dashboard.component.css
+++ b/frontend/src/app/auth/user-dashboard/user-dashboard.component.css
@@ -295,26 +295,19 @@ app-modalflow {
     overflow: hidden;
     box-shadow: 1px 1px 15px -5px black;
     transition: all 0.3s ease;
+    display: flex;
+    justify-content: center;
 }
 
 .avatar-main-wrapper .profile-pic {
     height: 100%;
-    width: 100%;
     transition: all 0.3s ease;
 }
-
-.avatar-main-wrapper .profile-pic:after {
-    font-family: FontAwesome;
-    content: '\f007';
-    top: 0;
-    left: 0;
-    width: 100%;
+.profile-pic-background {
     height: 100%;
-    position: absolute;
-    font-size: 140px;
-    background: #ecf0f1;
-    color: #34495e;
-    text-align: center;
+    width: 100%;
+    background-position: center;
+    background-size: cover;
 }
 
 .green-btn {

--- a/frontend/src/app/auth/user-dashboard/user-dashboard.component.html
+++ b/frontend/src/app/auth/user-dashboard/user-dashboard.component.html
@@ -40,12 +40,12 @@
                             class="profile-pic"
                             (click)="onEditInfos(personalInfos)"
                         ></div>
-                        <img
+                        <div
                             *ngIf="userAvatar"
-                            class="profile-pic"
-                            src="{{ userAvatar }}"
+                            class="profile-pic-background"
                             (click)="onEditInfos(personalInfos)"
-                        />
+                            [ngStyle]="{'background-image': 'url(' + userAvatar + ')'}"
+                        ></div>
                     </div>
                     <p (click)="onEditInfos(personalInfos)">
                         {{ username }} <i class="fa fa-pencil"></i>

--- a/frontend/src/app/auth/user-dashboard/user-dashboard.component.ts
+++ b/frontend/src/app/auth/user-dashboard/user-dashboard.component.ts
@@ -323,16 +323,49 @@ export class UserDashboardComponent implements OnInit {
     onUploadAvatar($event) {
         if ($event) {
             if ($event.target.files && $event.target.files[0]) {
-                const reader = new FileReader();
                 const file = $event.target.files[0];
-                reader.readAsDataURL(file);
-                reader.onload = () => {
-                    this.userAvatar = reader.result;
-                    this.newAvatar = reader.result;
-                    this.extentionFile = $event.target.files[0].type
-                        .split('/')
-                        .pop();
+                const img = document.createElement('img');
+                img.onload = (event) => {
+                    let newImage = null;
+                    if (event.target) {
+                        newImage = event.target;
+                    } else if (!event['path'] || !event['path'].length) {
+                        newImage = event['path'][0];
+                    }
+                    if (!newImage) {
+                        console.error('No image found on this navigator');
+                        return;
+                    }
+                    const canvas = document.createElement('canvas');
+                    const ctx = canvas.getContext('2d');
+
+                    let resizeTimeNumber = 1;
+                    const maxHeightRatio =
+                        newImage.height / AppConfig.imageUpload.maxHeight;
+                    if (maxHeightRatio > 1) {
+                        resizeTimeNumber = maxHeightRatio;
+                    }
+                    const maxWidthRatio =
+                        newImage.width / AppConfig.imageUpload.maxWidth;
+                    if (maxWidthRatio > 1 && maxWidthRatio > maxHeightRatio) {
+                        resizeTimeNumber = maxWidthRatio;
+                    }
+
+                    canvas.width = newImage.width / resizeTimeNumber;
+                    canvas.height = newImage.height / resizeTimeNumber;
+
+                    ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+
+                    const resizedImage = canvas.toDataURL(
+                        'image/jpeg',
+                        AppConfig.imageUpload.quality
+                    );
+
+                    this.userAvatar = resizedImage;
+                    this.newAvatar = resizedImage;
+                    this.extentionFile = 'jpeg';
                 };
+                img.src = window.URL.createObjectURL(file);
             }
         }
     }

--- a/frontend/src/app/core/topbar/topbar.component.css
+++ b/frontend/src/app/core/topbar/topbar.component.css
@@ -172,7 +172,7 @@ div.btn-group a:first-child {
     height: 22px;
     margin: 0;
     background: no-repeat;
-    background-size: contain;
+    background-size: cover;
     background-position: center;
     float: left;
     margin-right: 8px;

--- a/frontend/src/app/programs/observations/list/list.component.css
+++ b/frontend/src/app/programs/observations/list/list.component.css
@@ -61,7 +61,7 @@
     height: 22px;
     margin: 0;
     background: no-repeat;
-    background-size: contain;
+    background-size: cover;
     background-position: center;
     float: left;
     margin-right: 8px;

--- a/frontend/src/conf/app.config.ts.template
+++ b/frontend/src/conf/app.config.ts.template
@@ -70,5 +70,10 @@ export const AppConfig = {
     program_list_observers_names: true,
     program_list_sort: "-timestamp_create",
     details_espece_url: "<url_inpn_or_atlas>/cd_nom/", // !! gardez bien le cd_nom/ dans l'url
-    registration_message : "Vous inscrire vous permet de gérer vos observations"
+    registration_message : "Vous inscrire vous permet de gérer vos observations",
+    imageUpload: {
+        maxHeight: 1440,
+        maxWidth: 1440,
+        quality: 0.9,
+    }
 }


### PR DESCRIPTION
Bonjour ! 

Cette PR a pour but d'éviter de sauvegarder et d'afficher des images de plusieurs Mo.
Différents paramètres sont disponibles dans la configuration pour limiter les tailles des images:
```
maxHeight (hauteur maximale en pixels)
maxWidth (largeur maximale en pixels)
quality (entre 0 et 1)
```

Pour compresser et modifier la taille, j'ai utilisé un canvas, et plus particulièrement ces lignes:

```
ctx.drawImage(img, 0, 0, canvas.width, canvas.height); // Nouvelle taille de l'image en se basant sur la config et le ratio de l'image

const resizedImage = canvas.toDataURL(
    'image/jpeg',
    AppConfig.imageUpload.quality
); //gérénation d'une URL pour l'upload et compression
```

J'ai aussi utilisé un background: cover; pour éviter de déformer l'image en question à l'affichage