### PR TITLE
fix id_digitizer on gn_synthese.synthese

### DIFF
--- a/data/addons/scripts/gnc2gn_synthese/gnc2gn_synthese.sql
+++ b/data/addons/scripts/gnc2gn_synthese/gnc2gn_synthese.sql
@@ -174,7 +174,7 @@ BEGIN
         FROM
             gnc_obstax.t_obstax
                 join gnc_core.t_users on t_obstax.id_role = t_users.id_user
-                JOIN utilisateurs.t_roles ON t_users.email = t_users.email
+                JOIN utilisateurs.t_roles ON t_roles.email = t_users.email
         where
             t_obstax.id_role = new.id_role;
 


### PR DESCRIPTION
Fix wrong id_digitizer on [PnX-SI/GeoNature](https://github.com/PnX-SI/GeoNature) populate scripts

To apply to existing data, execute SQL Query:

```sql
update gnc_obstax.t_obstax set cd_nom=cd_nom;
```