### PR TITLE
fix: duplicated field in password auth

### DIFF
--- a/frontend/src/app/auth/register/register.component.html
+++ b/frontend/src/app/auth/register/register.component.html
@@ -167,7 +167,6 @@
                         #password="ngModel"
                         autocomplete="new-password"
                         required
-                        #password="ngModel"
                     />
                 </div>
             </div>


### PR DESCRIPTION
Périmètre: 
frontend/src/app/auth/register/register.component.html

Problème:
Attribut `#password ` définit deux fois

![image](https://github.com/PnX-SI/GeoNature-citizen/assets/150020787/2cc5df84-3a16-48d4-9204-615afe5813eb)

Solution: 
Suppression d'un des deux