### PR TITLE
Fix/email from

### DIFF
--- a/backend/gncitizen/core/users/routes.py
+++ b/backend/gncitizen/core/users/routes.py
@@ -494,9 +494,10 @@ def reset_user_password():
     html_message = current_app.config["RESET_PASSWD"]["HTML_TEMPLATE"].format(
         passwd=passwd, app_url=current_app.config["URL_APPLICATION"]
     )
-
+    from_addr = current_app.config["RESET_PASSWD"]["FROM"]
+    
     try:
-        send_user_email(subject, to, plain_message=plain_message, html_message=html_message)
+        send_user_email(subject, from_addr, to, plain_message=plain_message, html_message=html_message)
         user.password = passwd_hash
         db.session.commit()
         return (

--- a/backend/gncitizen/utils/mail_check.py
+++ b/backend/gncitizen/utils/mail_check.py
@@ -46,10 +46,11 @@ def send_user_email(subject: str, from_addr: str, to: str, plain_message: str = 
         server.ehlo()
         if current_app.config["MAIL"]["MAIL_STARTTLS"]:
             server.starttls()
-        server.login(
-            str(current_app.config["MAIL"]["MAIL_AUTH_LOGIN"]),
-            str(current_app.config["MAIL"]["MAIL_AUTH_PASSWD"]),
-        )
+        if current_app.config["MAIL"]["MAIL_AUTH_LOGIN"]:
+            server.login(
+                str(current_app.config["MAIL"]["MAIL_AUTH_LOGIN"]),
+                str(current_app.config["MAIL"]["MAIL_AUTH_PASSWD"]),
+            )
         server.sendmail(
             from_addr,
             to,

--- a/backend/gncitizen/utils/mail_check.py
+++ b/backend/gncitizen/utils/mail_check.py
@@ -6,10 +6,10 @@ from flask import current_app
 from itsdangerous import URLSafeTimedSerializer
 
 
-def send_user_email(subject: str, to: str, plain_message: str = None, html_message: str = None):
+def send_user_email(subject: str, from_addr: str, to: str, plain_message: str = None, html_message: str = None):
     msg = MIMEMultipart("alternative")
     msg["Subject"] = subject
-    msg["From"] = current_app.config["MAIL"]["MAIL_AUTH_LOGIN"]
+    msg["From"] = from_addr
     msg["To"] = to
     plain_msg = MIMEText(
         html_message,
@@ -51,7 +51,7 @@ def send_user_email(subject: str, to: str, plain_message: str = None, html_messa
             str(current_app.config["MAIL"]["MAIL_AUTH_PASSWD"]),
         )
         server.sendmail(
-            current_app.config["MAIL"]["MAIL_AUTH_LOGIN"],
+            from_addr,
             to,
             msg.as_string(),
         )
@@ -80,9 +80,11 @@ def confirm_user_email(newuser, with_confirm_link=True):
     template = current_app.config["CONFIRM_EMAIL"]["HTML_TEMPLATE"]
     if not with_confirm_link:
         template = current_app.config["CONFIRM_EMAIL"]["NO_VALIDATION_HTML_TEMPLATE"]
+    from_addr = current_app.config["CONFIRM_EMAIL"]["FROM"]
     try:
         send_user_email(
             subject,
+            from_addr,
             to,
             html_message=template.format(activate_url=activate_url),
         )


### PR DESCRIPTION
Périmètre: 
Le mail envoyé via send_user_email 

Problèmes:
1) les paramètres de provenance exprimées dans le config.toml sont ignorés. 
2) dans certains cas, il n'y a pas de besoin d'authentification. Un VPN suffit. Les paramètres laissés alors à '' entraînent une erreur. 

Solutions:
1) Ajout d'un paramètre "from_addr" à la méthode d'envoi d'email qui permet de rendre cette valeur configurable, et de transmettre les valeurs définies dans la conf. 
2) Ajout d'un test sur la valeur de 'login' avant envoi de l'email