### PR TITLE
Fix/load admin map center from config

### DIFF
--- a/backend/gncitizen/utils/env.py
+++ b/backend/gncitizen/utils/env.py
@@ -50,8 +50,8 @@ def load_config(config_file=None):
     config_gnc = load_toml(get_config_file_path())
     config_gnc["FLASK_ADMIN_FLUID_LAYOUT"] = True
     config_gnc["MAPBOX_MAP_ID"] = "light-v10"
-    config_gnc["DEFAULT_CENTER_LAT"] = 5
-    config_gnc["DEFAULT_CENTER_LONG"] = 45
+    config_gnc["DEFAULT_CENTER_LAT"] = config_gnc.get("DEFAULT_CENTER_LAT", 45)
+    config_gnc["DEFAULT_CENTER_LONG"] = config_gnc.get("DEFAULT_CENTER_LONG", 5)
     # config_gnc["JWT_ACCESS_TOKEN_EXPIRES"] = timedelta(seconds=20)
     # config_gnc["JWT_REFRESH_TOKEN_EXPIRES"] = timedelta(seconds=40)
     return config_gnc

--- a/backend/gncitizen/utils/env.py
+++ b/backend/gncitizen/utils/env.py
@@ -45,7 +45,7 @@ def valid_api_url(url):
     return url
 
 
-def load_config(config_file=None):
+def load_config():
     """Load the geonature-citizen configuration from a given file"""
     config_gnc = load_toml(get_config_file_path())
     config_gnc["FLASK_ADMIN_FLUID_LAYOUT"] = True

--- a/config/config.toml.template
+++ b/config/config.toml.template
@@ -71,3 +71,6 @@ REWARDS_ENABLED = false
 
 # API flasgger main config
 
+# Flaskadmin map default center
+DEFAULT_CENTER_LAT = 45
+DEFAULT_CENTER_LONG = 5


### PR DESCRIPTION
**Périmètre**: Centre de la map du panneau admin

**Problème**: La map est centrée de manière forcée sur la somalie

![image](https://github.com/PnX-SI/GeoNature-citizen/assets/150020787/c2eb1b0e-a28f-4bc1-9984-435ac390ebb4)

**Solution**: 
Ouvrir la possibilité d'avoir ces champs définis dans le toml
La possibilité de ne pas avoir ces champs définis dans le toml est conservée, par soucis de rétrocompatibilité
Au passage, le paramètre de la méthode "load_config", étant inutile, a été supprimé. 
La valeur par défaut est pour l'instant fixée arbitrairement à [45, 5].
