### PR TITLE
Fix/user creation from admin panel

### DIFF
--- a/backend/gncitizen/core/commons/admin.py
+++ b/backend/gncitizen/core/commons/admin.py
@@ -72,13 +72,10 @@ class CustomFormView(ModelView):
 
 
 class UserView(ModelView):
-    column_exclude_list = ["password"]
     form_excluded_columns = [
         "timestamp_create",
         "timestamp_update",
-        "password",
     ]
-    can_create = False
 
 
 def get_geom_file_path(obj, file_data):

--- a/backend/gncitizen/core/commons/admin.py
+++ b/backend/gncitizen/core/commons/admin.py
@@ -1,6 +1,5 @@
 #!/usr/bin/python3
 # -*- coding:utf-8 -*-
-import requests
 from flask import current_app, flash
 from flask_admin.contrib.sqla.view import ModelView
 from flask_admin.form.upload import FileUploadField
@@ -87,7 +86,6 @@ def get_geom_file_path(obj, file_data):
 
 
 class GeometryView(CustomTileView):
-    # column_exclude_list = ["geom"]
     form_excluded_columns = ["timestamp_create", "timestamp_update"]
     column_exclude_list = ["geom", "geom_file"]
     form_overrides = dict(geom_file=FileUploadField)

--- a/backend/gncitizen/core/users/models.py
+++ b/backend/gncitizen/core/users/models.py
@@ -7,6 +7,7 @@ from utils_flask_sqla_geo.serializers import serializable
 from gncitizen.core.commons.models import ProgramsModel, TimestampMixinModel, TModules
 from server import db
 
+from sqlalchemy import event
 
 class RevokedTokenModel(db.Model):
     __tablename__ = "t_revoked_tokens"
@@ -29,6 +30,7 @@ class RevokedTokenModel(db.Model):
 class UserModel(TimestampMixinModel, db.Model):
     """
     Table des utilisateurs
+    Note: Le mot de passe est haché à chaque mise à jour de la valeur par l'évènement hash_user_password déclaré ci-après
     """
 
     __tablename__ = "t_users"
@@ -108,6 +110,13 @@ class UserModel(TimestampMixinModel, db.Model):
     #     except:
     #         return {'message': 'Something went wrong'}
 
+
+@event.listens_for(UserModel.password, 'set', retval=True)
+def hash_user_password(target, value, oldvalue, initiator):
+    """Evenement qui hash le mot de passe systèmatiquement"""
+    if value != oldvalue:
+        return UserModel.generate_hash(value)
+    return value
 
 class GroupsModel(db.Model):
     """Table des groupes d'utilisateurs"""

--- a/backend/gncitizen/core/users/routes.py
+++ b/backend/gncitizen/core/users/routes.py
@@ -410,7 +410,7 @@ def logged_user():
                 }:
                     setattr(user, data, request_data[data])
             if "newPassword" in request_data:
-                user.password = UserModel.generate_hash(request_data["newPassword"])
+                user.password = request_data["newPassword"]
             user.admin = is_admin
             user.update()
             return (
@@ -484,7 +484,6 @@ def reset_user_password():
         )
 
     passwd = uuid.uuid4().hex[0:6]
-    passwd_hash = UserModel.generate_hash(passwd)
 
     subject = current_app.config["RESET_PASSWD"]["SUBJECT"]
     to = user.email
@@ -498,7 +497,7 @@ def reset_user_password():
     
     try:
         send_user_email(subject, from_addr, to, plain_message=plain_message, html_message=html_message)
-        user.password = passwd_hash
+        user.password = passwd
         db.session.commit()
         return (
             {"message": "Check your email, you credentials have been updated."},


### PR DESCRIPTION
**Périmètre**: création d'utilisateurs avec l'admin et gestion du hachage du mot de passe des utilisateurs

**Problème**:
La responsabilité du hachage des mots de passes est attribuée aux routes qui interagissent avec le UserModel.
Le formulaire de création d'utilisateur ne permet pas de créer un utilisateur, et ne contient pas le champs password.
Il aurait fallu appeler à un troisième endroit la méthode hachage

**Solution proposée**
- Déplacer la responsabilité du hachage au UserModel en ajoutant un sqlalchemy event pour forcer le hachage à chaque modification du mot de passe.
- Suppression de la contrainte empêchant la création d'un utilisateur depuis l'admin