### PR TITLE
Fix: reset password mail content

### DIFF
--- a/backend/gncitizen/core/users/routes.py
+++ b/backend/gncitizen/core/users/routes.py
@@ -494,13 +494,29 @@ def reset_user_password():
 
     subject = current_app.config["RESET_PASSWD"]["SUBJECT"]
     to = user.email
-    plain_message = current_app.config["RESET_PASSWD"]["TEXT_TEMPLATE"].format(
-        passwd=passwd, app_url=current_app.config["URL_APPLICATION"]
-    )
-    html_message = current_app.config["RESET_PASSWD"]["HTML_TEMPLATE"].format(
-        passwd=passwd, app_url=current_app.config["URL_APPLICATION"]
-    )
+
+    plain_message = None
+    if "TEXT_TEMPLATE" in current_app.config["RESET_PASSWD"]:
+        plain_message = current_app.config["RESET_PASSWD"]["TEXT_TEMPLATE"].format(
+            passwd=passwd, app_url=current_app.config["URL_APPLICATION"]
+        )
+    html_message = None
+    if "HTML_TEMPLATE" in current_app.config["RESET_PASSWD"]:
+        html_message = current_app.config["RESET_PASSWD"]["HTML_TEMPLATE"].format(
+            passwd=passwd, app_url=current_app.config["URL_APPLICATION"]
+        )
     from_addr = current_app.config["RESET_PASSWD"]["FROM"]
+
+    # Set a default value
+    if not (plain_message or html_message):
+        html_message = '''
+            Bonjour,<br/>
+            <br/>
+            Voici votre nouveau mot de passe:<br/>
+            {passwd}<br/>
+            <br/>
+            <a href="{app_url}">Connexion</a>
+        '''
 
     try:
         send_user_email(

--- a/config/config.toml.template
+++ b/config/config.toml.template
@@ -44,10 +44,12 @@ VERIFY_OBSERVATIONS_ENABLED = false
     Bonjour,\r\nVoici votre nouveau mot de passe :\r\n{passwd}\r\n"{app_url}
     '''
     HTML_TEMPLATE = '''
-    Bonjour,<br /><br />Voici votre nouveau mot de passe :<br />
-    {passwd}
-    <br /><br />"
-    <a href="{app_url}">Connexion</a>'
+    Bonjour,<br/>
+    <br/>
+    Voici votre nouveau mot de passe:<br/>
+    {passwd}<br/>
+    <br/>
+    <a href="{app_url}">Connexion</a>
     '''
 
 [CONFIRM_EMAIL]


### PR DESCRIPTION
[Contenu du mail de récupération du mot de passe]

Le cas du contenu de mail de récupération du mot de passe en html était en pratique ignoré.

En effet, la route ne permet pas d'avoir un des deux champs (TEXT_TEMPLATE ou HTML_TEMPLATE) non remplis.
Et il semble par la suite que le text_template prend le pas sur html_template. 

La solution proposée aussi rends ces champs optionnels, et ajout une valeur par défaut si ces champs ne sont pas renseignés. 
