### PR TITLE
Fix/ description observation and manage nested json "type" array

### DIFF
--- a/frontend/src/app/programs/base/detail/detail.component.css
+++ b/frontend/src/app/programs/base/detail/detail.component.css
@@ -37,3 +37,18 @@ h5.card-title {
     height: 225px;
     object-fit: contain;
 }
+
+.expandable-row {
+    cursor: pointer !important;
+    background-color: #f7f7f7; /* Light gray background */
+}
+
+.expandable-row:hover {
+    cursor: pointer !important;
+    background-color: lightblue !important; /* Darker gray background on hover */
+}
+
+.expanded {
+    cursor: pointer !important;
+    background-color: lightblue !important; /* Darker gray background on hover */
+}

--- a/frontend/src/app/programs/base/detail/detail.component.html
+++ b/frontend/src/app/programs/base/detail/detail.component.html
@@ -154,22 +154,39 @@
             </div>
         </div>
 
-    <div *ngIf="module === 'observations'">
-        <div *ngIf="attributes.length > 0" class="row">
-            <h2 class="mt-4 mb-4">Description</h2>
-        </div>
-        <div class="row bg-light">
-            <table class="table table-striped">
-                <tbody>
-                    <tr *ngFor="let d of attributes" class="d-flex">
-                        <td class="col-4">{{ d.name }}</td>
-                        <td class="col-8">{{ d.value }}</td>
-                    </tr>
-                </tbody>
-            </table>
+        <div *ngIf="module === 'observations'">
+            <div *ngIf="attributes.length > 0" class="row">
+                <h2 class="mt-4 mb-4">Description</h2>
+            </div>
+            <div class="row bg-light">
+                <table class="table table-striped">
+                    <tbody>
+                            <ng-container *ngFor="let d of attributes">
+                                <tr class="d-flex" (click)="d.type === 'array' ? toggleCollapse(d) : null" [ngClass]="{'expandable-row': d.type === 'array', 'expanded': d.showDetails}">
+                                    <td  [attr.colspan]="d.type === 'array' ? 2 : 1" class="col-4">{{ d.name }} <span *ngIf="d.type === 'array'">
+                                        <i class="fa fa-chevron-right" *ngIf="!d.showDetails"></i>
+                                        <i class="fa fa-chevron-down" *ngIf="d.showDetails"></i>
+                                        
+                                    </span></td>
+                                    <td  class="col-8">
+                                        <span *ngIf="!d.showDetails && d.type != 'array'">{{d.value}}</span>
+                                    </td>
+                                </tr>
+                                <ng-container *ngIf="d.type === 'array'">
+                                <ng-container *ngFor="let r of d.value">
+                                    <tr *ngIf="d.showDetails" class="additional-content expanded-row">
+                                        <td colspan="2" [innerHTML]="r">
+                                        </td>
+                                    </tr>
+                                </ng-container>
+                            </ng-container>
+                            </ng-container>
+                    </tbody>
+                </table>
+            </div>
         </div>
     </div>
-</div>
+
 
 
 <div class="modal fade" id="photoModal" tabindex="-1" role="dialog">

--- a/frontend/src/app/programs/base/detail/detail.component.html
+++ b/frontend/src/app/programs/base/detail/detail.component.html
@@ -95,40 +95,64 @@
             </div>
         </div>
     </div>
-    <div *ngIf="module === 'sites'">
-        <div *ngIf="attributes.length > 0" class="row">
-            <h2 class="my-4">Description</h2>
+        <div *ngIf="module === 'sites'">
+            <div *ngIf="attributes.length > 0" class="row">
+                <h2 class="my-4">Description</h2>
+            </div>
+            <!-- {{ attributes|json }} -->
+            <!-- <span *ngIf="site">{{ site.properties.visits|json }}</span> -->
+            <div *ngFor="let a of attributes" class="row bg-light my-3">
+                <h5>
+                    <i class="fa fa-calendar"></i>
+                    {{ a.date | date: 'longDate' }} par {{ a.author }}
+                    <i
+                        class="fa fa-edit text-primary"
+                        ngbTooltip="Editer"
+                        (click)="editSiteVisit(a);"
+                        *ngIf="a.author === username"
+                    ></i>
+                    &nbsp;
+                    <!-- {{ a|json }} deleteSiteVisit(a.id)-->
+                    <i
+                        class="fa fa-trash text-danger"
+                        ngbTooltip="Supprimer"
+                        (click)="openDelVisitModal(a.id)"
+                        *ngIf="a.author === username"
+                    ></i>
+                </h5>
+                <table class="table table-striped table-sm table-hover">
+                    <tbody>
+                        <ng-container *ngIf="a.data; else noData">
+                            <ng-container *ngFor="let d of a.data">
+                                <tr class="d-flex" (click)="d.type === 'array' ? toggleCollapse(d) : null" [ngClass]="{'expandable-row': d.type === 'array', 'expanded': d.showDetails}">
+                                    <td  [attr.colspan]="d.type === 'array' ? 2 : 1" class="col-4">{{ d.name }} <span *ngIf="d.type === 'array'">
+                                        <i class="fa fa-chevron-right" *ngIf="!d.showDetails"></i>
+                                        <i class="fa fa-chevron-down" *ngIf="d.showDetails"></i>
+                                        
+                                    </span></td>
+                                    <td  class="col-8">
+                                        <span *ngIf="!d.showDetails && d.type != 'array'">{{d.value}}</span>
+                                    </td>
+                                </tr>
+                                <ng-container *ngIf="d.type === 'array'">
+                                <ng-container *ngFor="let r of d.value">
+                                    <tr *ngIf="d.showDetails" class="additional-content expanded-row">
+                                        <td colspan="2" [innerHTML]="r">
+                                        </td>
+                                    </tr>
+                                </ng-container>
+                            </ng-container>
+                            </ng-container>
+                        </ng-container>
+                        <ng-template #noData>
+                            <tr class="d-flex">
+                                <td class="col-8">Aucune donnée</td>
+                            </tr>
+                        </ng-template>
+                    </tbody>
+                </table>
+            </div>
         </div>
-        <!-- {{ attributes|json }} -->
-        <!-- <span *ngIf="site">{{ site.properties.visits|json }}</span> -->
-        <div *ngFor="let a of attributes" class="row bg-light my-3">
-            <h5>
-                <i class="fa fa-calendar"></i>
-                {{ a.date | date: 'longDate' }} par {{ a.author }}
-                <i class="fa fa-edit text-primary" ngbTooltip="Editer" (click)="editSiteVisit(a);"
-                    *ngIf="a.author === username"></i>
-                &nbsp;
-                <!-- {{ a|json }} deleteSiteVisit(a.id)-->
-                <i class="fa fa-trash text-danger" ngbTooltip="Supprimer" (click)="openDelVisitModal(a.id)"
-                    *ngIf="a.author === username"></i>
-            </h5>
-            <table class="table table-striped table-sm table-hover">
-                <tbody>
-                    <ng-container *ngIf="a.data; else noData">
-                        <tr *ngFor="let d of a.data" class="d-flex">
-                            <td class="col-4">{{ d.name }}</td>
-                            <td class="col-8">{{ d.value }}</td>
-                        </tr>
-                    </ng-container>
-                    <ng-template #noData>
-                        <tr class="d-flex">
-                            <td class="col-8">Aucune donnée</td>
-                        </tr>
-                    </ng-template>
-                </tbody>
-            </table>
-        </div>
-    </div>
 
     <div *ngIf="module === 'observations'">
         <div *ngIf="attributes.length > 0" class="row">

--- a/frontend/src/app/programs/base/detail/detail.component.ts
+++ b/frontend/src/app/programs/base/detail/detail.component.ts
@@ -27,4 +27,7 @@ export abstract class BaseDetailComponent {
         this.clickedPhoto = photo;
         $('#photoModal').modal('show');
     }
+    toggleCollapse(data: any): void {
+        data.showDetails = !data.showDetails;
+    }
 }

--- a/frontend/src/app/programs/observations/detail/detail.component.ts
+++ b/frontend/src/app/programs/observations/detail/detail.component.ts
@@ -66,6 +66,7 @@ export class ObsDetailComponent
                 this.loadJsonSchema().subscribe((customform: any) => {
                     let schema = customform.json_schema.schema.properties;
                     let layout = customform.json_schema.layout;
+                    // TODO: changer questionnaire pour voir si le item.key sera pris en compte
                     for (const item of layout) {
                         let v = data[item.key];
                         if (v !== undefined) {

--- a/frontend/src/app/programs/observations/detail/detail.component.ts
+++ b/frontend/src/app/programs/observations/detail/detail.component.ts
@@ -61,21 +61,10 @@ export class ObsDetailComponent
 
             // prepare data
             if (this.obs.properties.json_data) {
-                let data = this.obs.properties.json_data;
-                var that = this;
+                const data = this.obs.properties.json_data;
                 this.loadJsonSchema().subscribe((customform: any) => {
-                    let schema = customform.json_schema.schema.properties;
-                    let layout = customform.json_schema.layout;
-                    // TODO: changer questionnaire pour voir si le item.key sera pris en compte
-                    for (const item of layout) {
-                        let v = data[item.key];
-                        if (v !== undefined) {
-                            that.attributes.push({
-                                name: schema[item.key].title,
-                                value: v.toString(),
-                            });
-                        }
-                    }
+                    const schema = customform.json_schema.schema.properties;
+                    this.attributes = this.formatData(data, schema);
                 });
             }
         });
@@ -85,5 +74,103 @@ export class ObsDetailComponent
         return this.http.get(
             `${this.URL}/programs/${this.program_id}/customform/`
         );
+    }
+
+    flatObject(object: object): object {
+        const flatObjectKeys = Object.keys(object);
+        let flatObject = { ...object };
+
+        flatObjectKeys.forEach(key => {
+            if (
+                flatObject[key].type === 'object' &&
+                Object.prototype.hasOwnProperty.call(
+                    flatObject[key],
+                    'properties'
+                )
+            ) {
+                flatObject = {
+                    ...flatObject[key].properties,
+                    ...flatObject,
+                };
+                delete flatObject[key];
+            }
+        });
+
+        return flatObject;
+    }
+
+    formatData(data: any, schema: any): any[] {
+        const formattedData: any[] = [];
+        this.flattenObject(data, schema, formattedData);
+        return formattedData;
+    }
+
+    flattenObject(
+        object: any,
+        schema: any,
+        formattedData: Array<{
+            name: string;
+            value: string | string[];
+            showDetails: boolean;
+            type: string;
+        }>
+    ): void {
+        const flatSchema = this.flatObject(schema);
+        const flatObject = this.flatObject(object);
+
+        for (const key in flatObject) {
+            if (Object.prototype.hasOwnProperty.call(flatSchema, key)) {
+                const value = flatObject[key];
+                const propSchema = flatSchema[key];
+
+                if (Array.isArray(value)) {
+                    const isArrayType = propSchema.type === 'array';
+                    const listFormattedString = value.map(item =>
+                        this.formatArrayItem(item, propSchema.items.properties)
+                    );
+                    formattedData.push({
+                        name: propSchema.title,
+                        value: listFormattedString,
+                        showDetails: isArrayType,
+                        type: propSchema.type,
+                    });
+                } else if (typeof value === 'object') {
+                    this.flattenObject(
+                        value,
+                        propSchema.items.properties,
+                        formattedData
+                    );
+                } else {
+                    const propName = propSchema.title;
+                    const isArrayType = propSchema.type === 'array';
+                    formattedData.push({
+                        name: propName,
+                        value:
+                            typeof value === 'boolean'
+                                ? value
+                                    ? 'Oui'
+                                    : 'Non'
+                                : value.toString(),
+                        showDetails: isArrayType,
+                        type: propSchema.type,
+                    });
+                }
+            }
+        }
+    }
+
+    formatArrayItem(item: any, schema: any): string {
+        let formattedString = '';
+
+        for (const key in item) {
+            const nestedValue = item[key];
+            const nestedSchema = schema[key];
+
+            formattedString += `<p>${
+                nestedSchema.title
+            }: ${nestedValue.toString()}</p>`;
+        }
+
+        return formattedString;
     }
 }


### PR DESCRIPTION
Bonjour , tout d'abord bravo pour tous ces dev et la sortie de la  version 1 de Citizen ! 

Ensuite dans le cadre d'une prestation pour l'ARB IDF , il  été remonté l'absence de "Description" pour les observations ainsi qu'un problème à l'affichage des type "array" récupéré dans le jsonchema.
Ce deuxième problème est également mentionné dans cette issue : #254 

Les devs proposés permettent de gérer les champs de type "array" à l'affichage dans le tableau ainsi que de pouvoir afficher la description d'une observation qui pour le moment ne semble pas être fonctionnel car la boucle sur la clé du layout s'arrête au niveau du champ "items". Cette PR résout ce problème . 

Concernant l'UX de l'affichage du champ de type "array" , j'ai opté sur l'affichage en mode dépliement du détail de la liste de données lié au champ de type "array" au "click" sur la ligne concernée (voir image ci dessous).  Une fois dépliée le background de ligne se met en light-blue. Ce choix se justifie sur le fait de ne pas avoir un tableau à rallonge suivant le nombre d'élément contenu dans le champ de type "array". 

Merci d'avance pour votre lecture et je suis biensur à l'écoute de retours / suggestions d'améliorations . 

Bonne journée  ! 

<details>  <summary> Image concernant la réprésentation coté frontend sur la gestion du champ de type "array"</summary>
![image](https://github.com/PnX-SI/GeoNature-citizen/assets/111564663/f4d4ccd1-b74b-47c0-a9b2-3138a8270501)

</details>


<details>  <summary> Image concernant l'affichage de la description d'une observation</summary>
![image](https://github.com/PnX-SI/GeoNature-citizen/assets/111564663/88e3014c-8522-4fc6-9737-10067903f39a)
</details>
