### PR TITLE
Fix #420 avoid scratch passwd

### DIFF
--- a/backend/gncitizen/core/users/models.py
+++ b/backend/gncitizen/core/users/models.py
@@ -1,13 +1,12 @@
 #!/usr/bin/env python3
 
 from flask import current_app
+from gncitizen.core.commons.models import ProgramsModel, TimestampMixinModel, TModules
 from passlib.hash import pbkdf2_sha256 as sha256
+from server import db
 from sqlalchemy import event
 from sqlalchemy.ext.declarative import declared_attr
 from utils_flask_sqla_geo.serializers import serializable
-
-from gncitizen.core.commons.models import ProgramsModel, TimestampMixinModel, TModules
-from server import db
 
 logger = current_app.logger
 
@@ -130,10 +129,11 @@ class UserModel(TimestampMixinModel, db.Model):
 def hash_user_password(_target, value, oldvalue, _initiator):
     """Evenement qui hash le mot de passe systèmatiquement"""
     logger.debug(f"<hash_user_password> OLD PWD {oldvalue} / NEW PWD {value != ''}")
+    print(f"PASSWORD VALUE {value} / OLDVALUE {oldvalue}")
     if value != "" and not sha256.identify(value):
         logger.debug("<hash_user_password> Update new password")
         return UserModel.generate_hash(value)
-    return value
+    return oldvalue
 
 
 class GroupsModel(db.Model):

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixes
 
 * Standardization of frontend map components between site and observation modules (#415 by @xavyeah39)
+* Fix password scratch when user profile edited from backoffice, cf. #420 (#429 by @hypsug0)
 
 ## 1.1.0 - 2024-04-06
 


### PR DESCRIPTION
Fix #420, if password field is empty on save from backoffice, old value is left.