### PR TITLE
[doc] fix clicnat-citizen url

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Documentation : https://geonature-citizen.readthedocs.io
 - https://enquetes.lashf.org
 - https://observatoire-biodiversite.parc-du-vercors.fr
 - https://enquetes-biodivrennes.fr
-- https://enquetes.clicnat.fr
+- https://citizen.clicnat.fr
 - https://obs-citoyenne.pyrenees-parcnational.fr
 - https://observation.lehavre.fr
 - https://enquetes.cbiodiv.org


### PR DESCRIPTION
Cette petite PR actualise simplement l'URL de Clicnat-Citizen dans la liste d'exemples du readme du repo.