### PR TITLE
Feat/add translation de and missing

### DIFF
--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -111,6 +111,29 @@
                             "i18nFormat": "xlf",
                             "i18nLocale": "en",
                             "i18nMissingTranslation": "error"
+                        },
+                        "de": {
+                            "optimization": true,
+                            "outputHashing": "all",
+                            "outputPath": "dist/browser/de/",
+                            "sourceMap": false,
+                            "extractCss": true,
+                            "namedChunks": false,
+                            "aot": true,
+                            "extractLicenses": true,
+                            "vendorChunk": false,
+                            "buildOptimizer": true,
+                            "fileReplacements": [
+                                {
+                                    "replace": "src/environments/environment.ts",
+                                    "with": "src/environments/environment.prod.ts"
+                                }
+                            ],
+                            "baseHref": "/de/",
+                            "i18nFile": "src/i18n/messages.de.xlf",
+                            "i18nFormat": "xlf",
+                            "i18nLocale": "de",
+                            "i18nMissingTranslation": "error"
                         }
                     }
                 },
@@ -128,6 +151,9 @@
                         },
                         "en": {
                             "browserTarget": "frontend:build:en"
+                        },
+                        "de": {
+                            "browserTarget": "frontend:build:de"
                         }
                     }
                 },
@@ -187,7 +213,7 @@
                             "srcDir": "src/i18n",
                             "genDir": "src/i18n",
                             "defaultLanguage": "fr",
-                            "languages": ["fr", "en"]
+                            "languages": ["fr", "en", "de"]
                         }
                     }
                 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
         "build": "ng build",
         "build:fr": "ng build --configuration=fr",
         "build:en": "ng build --configuration=en",
+        "build:de": "ng build --configuration=de",
         "test": "ng test",
         "lint": "ng lint",
         "e2e": "ng e2e",
@@ -18,7 +19,7 @@
         "build:ssr": "npm run build:client-and-server-bundles && npm run compile:server",
         "build:i18n-ssr": "npm run build:client-and-server-bundles-i18n && npm run compile:server",
         "build:client-and-server-bundles": "ng build --prod && ng run frontend:server:production",
-        "build:client-and-server-bundles-i18n": "ng run frontend:build:fr && ng run frontend:build:en && ng run frontend:server:production",
+        "build:client-and-server-bundles-i18n": "ng run frontend:build:fr && ng run frontend:build:en && ng run frontend:build:de && ng run frontend:server:production",
         "extract-i18n": "ng xi18n frontend --i18n-format xlf --output-path i18n --i18n-locale fr && ng run frontend:xliffmerge"
     },
     "private": true,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,6 +6,7 @@
         "start": "ng serve --poll 2000 --host 0.0.0.0 --port 4000",
         "start:fr": "ng serve --poll 2000 --configuration=fr",
         "start:en": "ng serve --poll 2000 --configuration=en",
+        "start:de": "ng serve --poll 2000 --configuration=de",
         "build": "ng build",
         "build:fr": "ng build --configuration=fr",
         "build:en": "ng build --configuration=en",

--- a/frontend/server.ts
+++ b/frontend/server.ts
@@ -18,7 +18,7 @@ const app = express();
 const PORT = process.env.PORT || 4000;
 const DIST_FOLDER = join(process.cwd(), 'dist/browser');
 
-const supportedLocales = ['en', 'fr'];
+const supportedLocales = ['de','en', 'fr'];
 const DEFAULT_LOCALE = 'fr';
 const MockBrowser = require('mock-browser').mocks.MockBrowser;
 const mock = new MockBrowser();

--- a/frontend/src/app/auth/register/register.component.html
+++ b/frontend/src/app/auth/register/register.component.html
@@ -104,8 +104,8 @@
                         i18n-placeholder="Your confirm password input@@yourPasswordConfirmInput"
                         placeholder="Confirmez le mot de passe" autocomplete="new-password" required
                         [ngModelOptions]="{ updateOn: 'blur' }" pattern="{{ password.value }}" />
-                    <div class="invalid-feedback">
-                        Please provide a valid city.
+                    <div class="invalid-feedback" i18n="Error message for invalid password@@invalidPasswordError">
+                        S'il vous plait entrez un mot de passe valide.
                     </div>
 
                 </div>
@@ -114,11 +114,12 @@
                 <ngb-alert [dismissible]="false" type="warning" *ngIf="cgu.errors" i18n="Accept UGC@@acceptUGC">
                     Veuillez accepter les conditions d'utilisation.
                 </ngb-alert>
-                <input type="checkbox" id="cgu" name="cgu" #cgu="ngModel" ngModel required
-                    i18n="I Accept@@iAcceptIntro" />
-                J'accepte les
+                <input type="checkbox" id="cgu" name="cgu" #cgu="ngModel" ngModel required/>
+                <div>
+                <p i18n="I Accept@@iAcceptIntro" style="display: inline;">J'accepte les </p>
                 <a target="_blank" href="{{ MainConfig['termsOfUse'][localeId] }}"
-                    i18n="Use condition@@conditionsOfUse">conditions d&apos;utilisation</a>
+                    i18n="Use condition@@conditionsOfUse" style="display: inline;">conditions d&apos;utilisation</a>
+                </div>
             </span>
         </div>
         <div *ngIf="MainConfig.HCAPTCHA_SITE_KEY !== null" class="form-row">

--- a/frontend/src/app/auth/user-dashboard/user-dashboard.component.html
+++ b/frontend/src/app/auth/user-dashboard/user-dashboard.component.html
@@ -10,7 +10,7 @@
                                 (tab === 'observations'
                                     ? 'btn-primary'
                                     : 'btn-dark')
-                            ">
+                            " i18n="Observations button@@myObservationsButton">
                             Mes observations
                             <strong class="badge badge-pill badge-info">{{
                                 stats?.platform_attendance
@@ -19,7 +19,7 @@
                         <button *ngIf="mysites?.features.length > 0" (click)="tab = 'sites'" [class]="
                                 'btn ml-1 ' +
                                 (tab === 'sites' ? 'btn-primary' : 'btn-dark')
-                            ">
+                            " i18n="Sites button@@mySitesButton">
                             Mes sites
                             <strong class="badge badge-pill badge-info">{{
                                 mysites?.features.length
@@ -31,7 +31,7 @@
                         <div *ngIf="userAvatar" class="profile-pic-background" (click)="onEditInfos(personalInfos)"
                             [ngStyle]="{'background-image': 'url(' + userAvatar + ')'}"></div>
                     </div>
-                    <p (click)="onEditInfos(personalInfos)">
+                    <p (click)="onEditInfos(personalInfos)" i18n="Username@@username">
                         {{ username }} <i class="fa fa-pencil"></i>
                     </p>
                 </div>
@@ -51,7 +51,7 @@
                     </div>
                 </div>
                 <div *ngIf="programs_badges && programs_badges.length > 0" class="inner-row">
-                    <h5>Récompenses par programmes</h5>
+                    <h5 i18n="Program Awards@@programAwards">Récompenses par programmes</h5>
                     <div class="row">
                         <img *ngFor="let p_badge of programs_badges" loading="lazy"
                             [src]="MainConfig.API_ENDPOINT + p_badge.url" [alt]="p_badge.type + p_badge.name"
@@ -61,7 +61,7 @@
                     </div>
                 </div>
                 <div *ngIf="recognition_badges && recognition_badges.length > 0" class="inner-row">
-                    <h5>Récompenses d'identification d'espèces</h5>
+                    <h5 i18n="Recognition Awards@@recognitionAwards">Récompenses d'identification d'espèces</h5>
                     <div class="row">
                         <img *ngFor="let r_badge of recognition_badges" loading="lazy"
                             [src]="MainConfig.API_ENDPOINT + r_badge.url" [alt]="r_badge.type + r_badge.name"
@@ -99,8 +99,7 @@
             <section class="homeLink">
                 <a [routerLink]="['/']">
                     <i class="fa fa-arrow-left"></i>
-                    <ng-container i18n="back@@back"></ng-container>Retour au
-                    site
+                    <ng-container i18n="back@@backSite">Retour au site</ng-container>
                 </a>
             </section>
         </div>
@@ -215,7 +214,7 @@
                                 userForm.errors &&
                                 userForm.errors.MatchPassword &&
                                 userForm.controls.confirmPassword.dirty
-                            " class="danger">
+                            " class="danger" i18n="Password mismatch@@passwordMismatch">
                             * Le mot de passe n'est pas identique.
                         </p>
                     </div>
@@ -234,16 +233,16 @@
     <div class="modal-delete-header">
         <h5 class="modal-delete-title"><i class="fa fa-trash"></i></h5>
     </div>
-    <div class="modal-delete-body">
+    <div class="modal-delete-body" i18n="Delete observation confirmation@@deleteObservationConfirmation">
         Êtes-vous sûr de vouloir supprimer cette observation ?
         <br />
         Sa suppression sera définitive
     </div>
     <div class="modal-delete-footer">
-        <button type="button" class="cancel-btn" style="margin-right: 15px" (click)="onCancelDelete()">
+        <button type="button" class="cancel-btn" style="margin-right: 15px" (click)="onCancelDelete()" i18n="Cancel@@cancel">
             ANNULER
         </button>
-        <button type="button" class="green-btn" (click)="onDeleteObs()">
+        <button type="button" class="green-btn" (click)="onDeleteObs()" i18n="Yes@@yes">
             OUI
         </button>
     </div>
@@ -253,17 +252,17 @@
     <div class="modal-delete-header">
         <h5 class="modal-delete-title"><i class="fa fa-trash"></i></h5>
     </div>
-    <div class="modal-delete-body">
+    <div class="modal-delete-body" i18n="Delete site confirmation@@deleteSiteConfirmation">
         Êtes-vous sûr de vouloir supprimer ce site et toutes les informations
         qui y sont rattachées ?
         <br />
         La suppression sera définitive
     </div>
     <div class="modal-delete-footer">
-        <button type="button" class="cancel-btn" style="margin-right: 15px" (click)="onSiteCancelDelete()">
+        <button type="button" class="cancel-btn" style="margin-right: 15px" (click)="onSiteCancelDelete()" i18n="Cancel@@cancel">
             ANNULER
         </button>
-        <button type="button" class="green-btn" (click)="onDeleteSite()">
+        <button type="button" class="green-btn" (click)="onDeleteSite()" i18n="Yes@@yes">
             OUI
         </button>
     </div>

--- a/frontend/src/app/page-not-found/page-not-found.component.html
+++ b/frontend/src/app/page-not-found/page-not-found.component.html
@@ -3,14 +3,14 @@
         <div class="text-center">
             <div class="card">
                 <div class="card-body">
-                    <h1 class="card-title">Page not found</h1>
+                    <h1 class="card-title" i18n="Title for 404 error page@@pageNotFoundTitle">Page non trouvé</h1>
                     <p class="card-text">
                         <i
                             class="fa fa-3x fa-exclamation-triangle"
                             aria-hidden="true"
                         ></i>
                     </p>
-                    <p class="card-text">Error 404</p>
+                    <p class="card-text" i18n="Text for 404 error@@error404Text">Erreur 404</p>
                 </div>
             </div>
         </div>

--- a/frontend/src/app/programs/base/detail/detail.component.html
+++ b/frontend/src/app/programs/base/detail/detail.component.html
@@ -1,6 +1,6 @@
 <div class="container">
     <div class="row">
-        <a [routerLink]="['/programs', program_id, module]" queryParamsHandling="preserve" id="back_link">
+        <a [routerLink]="['/programs', program_id, module]" queryParamsHandling="preserve" id="back_link" i18n="Link to go back to the program@@backToProgramLink">
             <i class="fa fa-caret-left" aria-hidden="true"></i>
             Retour au programme</a>
     </div>
@@ -16,7 +16,7 @@
                 }}
             </h1>
             <p class="card-subtitle mb-2 text-muted">
-                <small>Ajoutée le
+                <small i18n="Text for added date and observer@@addedDateObserverText">Ajoutée le
                     {{ (module === 'sites' ? site?.properties.timestamp_create.substring(0, 10) :
                     obs?.properties.timestamp_create.substring(0, 10))
                     | date: 'longDate'
@@ -36,7 +36,8 @@
 
                 <p *ngIf="site?.properties.visits.length > 0; else noVisit" class="card-text">
                     <small class="text-muted">
-                        <span *ngIf="site?.properties.visits.length === 1">
+                        <span *ngIf="site?.properties.visits.length === 1"
+                        i18n="Text for a single site visit date@@singleSiteVisitText">
                             Visite du
                             {{
                             site?.properties.visits[0].date
@@ -50,27 +51,27 @@
                 </p>
                 <ng-template #noVisit>
                     <p class="card-text">
-                        <small class="text-danger">Aucune visite enregistrée :(</small>
+                        <small class="text-danger"  i18n="No visits recorded message@@noVisitsMessage">Aucune visite enregistrée :(</small>
                     </p>
                 </ng-template>
-                <a href="#" (click)="$event.preventDefault(); addSiteVisit()" class="btn btn-primary">Ajouter un rapport
+                <a href="#" (click)="$event.preventDefault(); addSiteVisit()" class="btn btn-primary" 
+                i18n="Button to add a site visit report@@addSiteVisitReportButton">Ajouter un rapport
                     de visite</a>
             </div>
         </div>
         <ng-template #obsDisplay>
             <div class="col-md-4 pt-2 card box-shadow">
                 <div class="card-body">
-                    <h5 class="card-title">Observation #{{ obs_id }}</h5>
+                    <h5 class="card-title" i18n="Observation card title with ID@@observationCardTitle">Observation #{{ obs_id }}</h5>
                     <p class="card-subtitle mb-2 text-muted">
-                        Observateur&nbsp;: {{ obs?.properties.obs_txt }}<br>
-                        Date&nbsp;: {{
-                        obs?.properties.date.substring(0, 10)
-                        | date: 'longDate'
-                        }}<br>
-                        {{ obs?.properties.municipality ? 'Commune&nbsp;: '+obs?.properties.municipality :
-                        null }}<br>
-                        Nombre&nbsp;: {{ obs?.properties.count}}
-                    </p>
+                        <span i18n="Observer label@@observerLabel">Observateur&nbsp;:</span> {{ obs?.properties.obs_txt }}<br>
+                        <span i18n="Date label@@dateLabel">Date&nbsp;:</span> {{ obs?.properties.date.substring(0, 10) | date: 'longDate' }}<br>
+                        <span *ngIf="obs?.properties.municipality">
+                          <span i18n="Municipality label@@municipalityLabel">Commune&nbsp;:</span> {{ obs?.properties.municipality }}
+                        </span><br>
+                        <span i18n="Count label@@countLabel">Nombre&nbsp;:</span> {{ obs?.properties.count }}
+                      </p>
+                      
                 </div>
             </div>
         </ng-template>
@@ -80,7 +81,7 @@
     </div>
     <div *ngIf="photos.length> 0" class="row mb-4">
         <div class="col-12">
-            <h2 class="my-2">Photos</h2>
+            <h2 class="my-2" i18n="Section title for photos@@photosSectionTitle">Photos</h2>
         </div>
         <div *ngFor="let photo of photos" class="col-md-4 col-lg-4 photo" (click)="showPhoto(photo)">
             <div class="card mb-4 box-shadow">
@@ -89,7 +90,7 @@
                     src="{{ photo.url }}" data-holder-rendered="true" />
                 <div class="card-body">
                     <p class="card-text text-muted">
-                        <small>Le {{ photo.date | date: 'longDate' }} par {{ photo.author }}</small>
+                        <small i18n="Photo date and author label@@photoDateAuthorLabel">Le {{ photo.date | date: 'longDate' }} par {{ photo.author }}</small>
                     </p>
                 </div>
             </div>
@@ -97,21 +98,23 @@
     </div>
     <div *ngIf="module === 'sites'">
         <div *ngIf="attributes.length > 0" class="row">
-            <h2 class="my-4">Description</h2>
+            <h2 class="my-4" i18n="Section title for description@@descriptionSectionTitle">Description</h2>
         </div>
         <!-- {{ attributes|json }} -->
         <!-- <span *ngIf="site">{{ site.properties.visits|json }}</span> -->
         <div *ngFor="let a of attributes" class="row bg-light my-3">
-            <h5>
+            <h5 i18n="Date and author for site visit@@siteVisitDateAuthor">
                 <i class="fa fa-calendar"></i>
                 {{ a.date | date: 'longDate' }} par {{ a.author }}
-                <i class="fa fa-edit text-primary" ngbTooltip="Editer" (click)="editSiteVisit(a);"
-                    *ngIf="a.author === username"></i>
+                <i class="fa fa-edit text-primary" ngbTooltip="Editer" 
+                   i18n-ngbTooltip="Tooltip for edit site visit@@editSiteVisitTooltip"
+                   (click)="editSiteVisit(a);" *ngIf="a.author === username"></i>
                 &nbsp;
-                <!-- {{ a|json }} deleteSiteVisit(a.id)-->
-                <i class="fa fa-trash text-danger" ngbTooltip="Supprimer" (click)="openDelVisitModal(a.id)"
-                    *ngIf="a.author === username"></i>
+                <i class="fa fa-trash text-danger" ngbTooltip="Supprimer" 
+                   i18n-ngbTooltip="Tooltip for delete site visit@@deleteSiteVisitTooltip"
+                   (click)="openDelVisitModal(a.id)" *ngIf="a.author === username"></i>
             </h5>
+            
             <table class="table table-striped table-sm table-hover">
                 <tbody>
                     <ng-container *ngIf="a.data; else noData">
@@ -122,7 +125,7 @@
                     </ng-container>
                     <ng-template #noData>
                         <tr class="d-flex">
-                            <td class="col-8">Aucune donnée</td>
+                            <td class="col-8"  i18n="No data available message@@noDataMessage">Aucune donnée</td>
                         </tr>
                     </ng-template>
                 </tbody>
@@ -132,7 +135,7 @@
 
     <div *ngIf="module === 'observations'">
         <div *ngIf="attributes.length > 0" class="row">
-            <h2 class="mt-4 mb-4">Description</h2>
+            <h2 class="mt-4 mb-4" i18n="Section title for description@@descriptionSectionTitle">Description</h2>
         </div>
         <div class="row bg-light">
             <table class="table table-striped">
@@ -166,8 +169,8 @@
                 </p>
             </div>
             <div class="modal-footer">
-                <button type="button" class="btn btn-secondary" data-dismiss="modal">
-                    Close
+                <button type="button" class="btn btn-secondary" data-dismiss="modal" i18n="close modal@@closeModal">
+                    Fermer
                 </button>
             </div>
         </div>
@@ -178,17 +181,20 @@
     <div class="modal-delete-header">
         <h5 class="modal-delete-title"><i class="fa fa-trash"></i></h5>
     </div>
-    <div class="modal-delete-body">
+    <div class="modal-delete-body"
+    i18n="Confirmation message for deleting a site visit@@deleteSiteVisitConfirmation">
         Êtes-vous sûr de vouloir supprimer cette visite et toutes les informations
         qui y sont rattachées ?
         <br />
         La suppression sera définitive
     </div>
     <div class="modal-delete-footer">
-        <button type="button" class="cancel-btn" style="margin-right: 15px" (click)="visitDeleteModalClose()">
+        <button type="button" class="cancel-btn" style="margin-right: 15px" (click)="visitDeleteModalClose()"
+        i18n="Cancel@@cancel">
             ANNULER
         </button>
-        <button type="button" class="green-btn" (click)="deleteSiteVisit(idVisitToDelete); visitDeleteModalClose();">
+        <button type="button" class="green-btn" (click)="deleteSiteVisit(idVisitToDelete); visitDeleteModalClose();"
+        i18n="Yes@@yes">
             OUI
         </button>
     </div>

--- a/frontend/src/app/programs/media-galery/media-galery.component.html
+++ b/frontend/src/app/programs/media-galery/media-galery.component.html
@@ -4,7 +4,7 @@
             <img loading="lazy" class="" [src]="API_ENDPOINT+ '/media/' + m.filename" [alt]="m.title"
                 [ngbTooltip]="m.name" />
             <div (click)="showPhoto(m)" class="overlay p-1">
-                <span><a [href]="m.data_url">{{ m.name }} le {{ m.date | date: 'longDate' }}</a> par @{{
+                <span i18n="Link text for observation details@@observationDetailsLink"><a [href]="m.data_url">{{ m.name }} le {{ m.date | date: 'longDate' }}</a> par @{{
                     m.observer
                     }}
                 </span>
@@ -25,7 +25,7 @@
     <div class="modal-dialog modal-dialog-centered modal-xl" role="document">
         <div class="modal-content">
             <div class="modal-header">
-                <h5 class="modal-title" id="exampleModalLabel">
+                <h5 class="modal-title" id="exampleModalLabel"  i18n="Modal title for clicked photo@@clickedPhotoModalTitle">
                     {{ clickedPhoto.name }} le
                     {{ clickedPhoto.date | date: 'longDate' }} par @{{
                     clickedPhoto.observer
@@ -34,7 +34,7 @@
                 <button type="button" class="close" data-dismiss="modal" aria-label="Close">
                     <span aria-hidden="true">&times;</span>
                 </button>
-            </div>
+            </div> 
             <div class="modal-body">
                 <img [src]="
                     API_ENDPOINT+'/media/' +

--- a/frontend/src/app/programs/observations/form/form.component.html
+++ b/frontend/src/app/programs/observations/form/form.component.html
@@ -23,7 +23,7 @@
         <div class="form-group col-lg-12 col-md-12">
             <input formControlName="id_program" type="hidden" />
             <h5 *ngIf="taxaCount > 1" class="m-0">
-                <label for="cd_nom" class="m-0">{ autocomplete, select, isOn {Rechercher une esp&egrave;ce}
+                <label for="cd_nom" class="m-0" i18n="Label for species search and selection@@speciesSearchSelectionLabel">{ autocomplete, select, isOn {Rechercher une esp&egrave;ce}
                     isOff {S&eacute;lectionnez une esp&egrave;ce}}</label>
             </h5>
             <!-- TAXON SELECT -->
@@ -34,7 +34,7 @@
                     taxaCount < taxonAutocompleteInputThreshold
                 " class="d-inline-flex toolbar ">
                         <select formControlName="cd_nom" class="form-control w-100" required>
-                            <option value="" [disabled]="true">Choisissez une espèce</option>
+                            <option value="" [disabled]="true" i18n="Option to choose a species@@chooseSpeciesOption">Choisissez une espèce</option>
                             <option *ngFor="let s of surveySpecies" [value]="s.taxref.cd_nom">
                                 {{
                                 !!s.nom_francais
@@ -80,7 +80,9 @@
                         <ngb-highlight [result]="r.name" [term]="t"></ngb-highlight>
                     </ng-template>
                     <input id="cd_nom" type="text" class="form-control" formControlName="cd_nom"
-                        placeholder="Nom latin ou vernaculaire ou cd_ref" [editable]="false"
+                        placeholder="Nom latin ou vernaculaire ou cd_ref"
+                        i18n-placeholder="Placeholder for species name input@@speciesNamePlaceholder"
+                        [editable]="false"
                         [ngbTypeahead]="inputAutoCompleteSearch" [resultTemplate]="rt"
                         [inputFormatter]="inputAutoCompleteFormatter" required />
                 </div>

--- a/frontend/src/app/programs/observations/list/list.component.html
+++ b/frontend/src/app/programs/observations/list/list.component.html
@@ -65,9 +65,13 @@
                               '?h=80'
                             : 'assets/default_image.png'
                     " />
-                        <span *ngIf="o.properties.photos && !!o.properties.photos.length" class="overlay-text"><i
-                                class="fa fa-camera" aria-hidden="true" placement="right"
-                                ngbTooltip="Observation avec photo"></i></span>
+                    <span *ngIf="o.properties.photos && !!o.properties.photos.length" class="overlay-text">
+                        <i class="fa fa-camera" aria-hidden="true" placement="right" 
+                           ngbTooltip="Observation avec photo" 
+                           i18n-ngbTooltip="Tooltip for observation with photo@@observationWithPhotoTooltip">
+                        </i>
+                    </span>
+                    
                     </div>
                     <div class="infos">
                         <div>
@@ -93,21 +97,30 @@
                             </ng-template>
 
                             &nbsp;
-                            <span *ngIf="MainConfig.VERIFY_OBSERVATIONS_ENABLED" (click)="onValidateClick(o)"
-                                [ngStyle]="{ 'cursor': o.properties.observer?.username == username ? 'not-allowed' :  'pointer'}">
-                                <i *ngIf="o.properties.validation_status && o.properties.validation_status === 'NOT_VALIDATED'"
-                                    class="fa fa-hourglass-half text-warning" aria-hidden="true" placement="bottom"
-                                    ngbTooltip="Observation non validée{{o.properties.observer?.username == username ? ' - Validation par un tiers requise' : ''}}"></i>
-                                <i *ngIf="o.properties.validation_status && o.properties.validation_status === 'INVALID'"
-                                    class="fa fa-question-circle text-danger" aria-hidden="true" placement="bottom"
-                                    ngbTooltip="Observation invalide{{o.properties.observer?.username == username ? ' - Validation par un tiers requise' : ''}}"></i>
-                                <i *ngIf="o.properties.validation_status && o.properties.validation_status === 'NON_VALIDATABLE'"
-                                    class="fa fa-times-circle text-danger" aria-hidden="true" placement="bottom"
-                                    ngbTooltip="Observation non validable{{o.properties.observer?.username == username ? ' - Validation par un tiers requise' : ''}}"></i>
-                                <i *ngIf="o.properties.validation_status && o.properties.validation_status === 'VALIDATED'"
-                                    class="fa fa-certificate text-success" aria-hidden="true" placement="bottom"
-                                    ngbTooltip="Observation approuvée"></i>
-                            </span>
+                        <span *ngIf="MainConfig.VERIFY_OBSERVATIONS_ENABLED" (click)="onValidateClick(o)"
+                            [ngStyle]="{ 'cursor': o.properties.observer?.username == username ? 'not-allowed' :  'pointer'}">
+                          <i *ngIf="o.properties.validation_status && o.properties.validation_status === 'NOT_VALIDATED'"
+                             class="fa fa-hourglass-half text-warning" aria-hidden="true" placement="bottom"
+                             ngbTooltip="Observation non validée{{o.properties.observer?.username == username ? ' - Validation par un tiers requise' : ''}}"
+                             i18n-ngbTooltip="Tooltip for non-validated observation@@nonValidatedObservationTooltip">
+                          </i>
+                          <i *ngIf="o.properties.validation_status && o.properties.validation_status === 'INVALID'"
+                             class="fa fa-question-circle text-danger" aria-hidden="true" placement="bottom"
+                             ngbTooltip="Observation invalide{{o.properties.observer?.username == username ? ' - Validation par un tiers requise' : ''}}"
+                             i18n-ngbTooltip="Tooltip for invalid observation@@invalidObservationTooltip">
+                          </i>
+                          <i *ngIf="o.properties.validation_status && o.properties.validation_status === 'NON_VALIDATABLE'"
+                             class="fa fa-times-circle text-danger" aria-hidden="true" placement="bottom"
+                             ngbTooltip="Observation non validable{{o.properties.observer?.username == username ? ' - Validation par un tiers requise' : ''}}"
+                             i18n-ngbTooltip="Tooltip for non-validatable observation@@nonValidatableObservationTooltip">
+                          </i>
+                          <i *ngIf="o.properties.validation_status && o.properties.validation_status === 'VALIDATED'"
+                             class="fa fa-certificate text-success" aria-hidden="true" placement="bottom"
+                             ngbTooltip="Observation approuvée"
+                             i18n-ngbTooltip="Tooltip for validated observation@@validatedObservationTooltip">
+                          </i>
+                      </span>
+                      
 
                         </div>
                         <div *ngIf="MainConfig.program_list_observers_names">
@@ -130,19 +143,24 @@
                                 &nbsp;
                                 <app-modalflow [coords]="o.properties.coords" [updateData]="o.properties"
                                     [program_id]="o.properties.id_program" *ngIf="'TODO dashboard condition'">
-                                    <i class="fa fa-edit text-primary" placement="top" ngbTooltip="Editer" btn-open></i>
+                                    <i class="fa fa-edit text-primary" placement="top" ngbTooltip="Editer" i18n-ngbTooltip="Tooltip for edit button@@editButtonTooltip"
+                                    btn-open></i>
                                 </app-modalflow>
                                 &nbsp;
-                                <i class="fa fa-trash text-danger" placement="top" ngbTooltip="Supprimer" (click)="
+                                <i class="fa fa-trash text-danger" placement="top" ngbTooltip="Supprimer"  i18n-ngbTooltip="Tooltip for delete button@@deleteButtonTooltip"
+                                 (click)="
                                     deleteObs.emit(o.properties.id_observation)
                                 " owner-actions></i>
                             </span>
                         </div>
                         <p>
-                            le <span>{{ o.properties.date }}</span>
+                            <span i18n="Date prefix@@datePrefix">le</span> 
+                            <span>{{ o.properties.date }}</span>
                             <span *ngIf="o.properties.municipality">
-                                à {{ o.properties.municipality }}</span>
-                        </p>
+                              <span i18n="Location prefix@@locationPrefix">à</span> {{ o.properties.municipality }}
+                            </span>
+                          </p>
+                          
                     </div>
                     <div class="hide detail-link" [routerLink]="[
                         '/programs',
@@ -150,7 +168,8 @@
                         'observations',
                         o.properties.id_observation
                     ]" queryParamsHandling="preserve" style="cursor: pointer" placement="left"
-                        ngbTooltip="Voir les détails de cette observation">
+                        ngbTooltip="Voir les détails de cette observation"
+                        i18n-ngbTooltip="Tooltip for viewing observation details@@viewObservationDetailsTooltip">
                         <img src="assets/binoculars.png" />
                     </div>
                 </div>

--- a/frontend/src/app/programs/observations/map/map.component.html
+++ b/frontend/src/app/programs/observations/map/map.component.html
@@ -2,5 +2,6 @@
     [id]="'obsMap'"
     class="obsMap"
     data-observation-zoom-statement-warning="Veuillez zoomer pour localiser votre observation."
+    i18n-data-observation-zoom-statement-warning="Warning message for zoom on observation map@@zoomWarning"
     #map
 ></div>

--- a/frontend/src/app/programs/observations/modalflow/steps/committed/committed.component.html
+++ b/frontend/src/app/programs/observations/modalflow/steps/committed/committed.component.html
@@ -17,7 +17,7 @@
         <span class="mr-3"><i class="fa fa-info-circle fa-2x" aria-hidden="true"></i>
         </span>
         <div class="media-body">
-            <h5 class="mt-0">Information</h5>
+            <h5 class="mt-0"  i18n="Heading for information section@@informationHeading">Information</h5>
             <span [innerHtml]="data.form_message"></span>
         </div>
     </div>

--- a/frontend/src/app/programs/observations/modalflow/steps/onboard/onboard.component.html
+++ b/frontend/src/app/programs/observations/modalflow/steps/onboard/onboard.component.html
@@ -11,7 +11,7 @@
             <span class="mr-3"><i class="fa fa-info-circle fa-2x" aria-hidden="true"></i>
             </span>
             <div class="media-body">
-                <h5 class="mt-0">Pourquoi s'inscrire ?</h5>
+                <h5 class="mt-0"  i18n="Heading for why to register@@whyRegisterHeading">Pourquoi s'inscrire ?</h5>
                 <span [innerHtml]="MainConfig.registration_message"></span>
             </div>
         </div>

--- a/frontend/src/app/programs/observations/obs.component.html
+++ b/frontend/src/app/programs/observations/obs.component.html
@@ -43,15 +43,13 @@
                 (validateObs)="openValidateModal(validateModal, $event)">
                 <button type="button" class="btn btn-success float-right" add-obs (click)="addObsClicked()"
                     *ngIf="!userDashboard && !validationDashboard" ngbTooltip="Ajouter une observation"
-                    placement="left">
-                    Ajouter
+                    placement="left" i18n-ngbTooltip="Ajouter une observation@@addObservationTooltip">
+                    <span i18n="Add button text@@addButtonText">Ajouter</span>
                 </button>
 
                 <app-modalflow #modalFlowRef [coords]="coords" [program_id]="program_id"
                     [registration_required]="program?.registration_required" [form_message]="program?.form_message"
-                    [modalversion]="
-                        MainConfig.FRONTEND.NEW_OBS_FORM_MODAL_VERSION
-                    " obs-form>
+                    [modalversion]="MainConfig.FRONTEND.NEW_OBS_FORM_MODAL_VERSION" obs-form>
                 </app-modalflow>
             </app-obs-list>
         </div>

--- a/frontend/src/app/programs/observations/validation/validation.component.html
+++ b/frontend/src/app/programs/observations/validation/validation.component.html
@@ -27,13 +27,16 @@
             " class="object-fit-cover" />
     </div>
     <div class="form-group col-lg-12">
-        <h5>
-            Identification proposée : {{ obsToValidate.properties.nom_francais ||
-            obsToValidate.properties.taxref.nom_vern}} <span *ngIf="MainConfig.taxonDisplaySciName">(<i>{{
-                    obsToValidate.properties.taxref.lb_nom }}</i>)</span>
-        </h5>
+        <h5 i18n="Title for identification proposed@@proposedIdentification">
+            Identification proposée : 
+            <ng-container>{{ obsToValidate.properties.nom_francais || obsToValidate.properties.taxref.nom_vern }}</ng-container>
+            <span *ngIf="MainConfig.taxonDisplaySciName">
+              (<i>{{ obsToValidate.properties.taxref.lb_nom }}</i>)
+            </span>
+          </h5>
+          
         <p *ngIf="taxaCount > 1" class="m-0">
-            <label for="cd_nom" class="m-0">{ autocomplete, select, isOn {Rechercher une esp&egrave;ce}
+            <label for="cd_nom" class="m-0" i18n="Label for species search or validation@@speciesSearchOrValidation">{ autocomplete, select, isOn {Rechercher une esp&egrave;ce}
                 isOff {Validez ou corrigez l&apos;esp&egrave;ce}}</label>
         </p>
         <!-- TAXON SELECT -->
@@ -43,7 +46,7 @@
                 taxaCount < taxonAutocompleteInputThreshold
             " class="d-inline-flex toolbar">
             <select formControlName="cd_nom" class="form-control rounded-0" [value]="obsToValidate.properties.cd_nom">
-                <option value="" [disabled]="true">Choisissez une espèce</option>
+                <option value="" [disabled]="true" i18n="Option to choose a species@@chooseSpeciesOption">Choisissez une espèce</option>
                 <option *ngFor="let s of surveySpecies" [value]="s.taxref.cd_nom">
                     {{
                     !!s.nom_francais
@@ -89,7 +92,9 @@
             <ngb-highlight [result]="r.name" [term]="t"></ngb-highlight>
         </ng-template>
         <input id="cd_nom" type="text" class="form-control rounded-0" formControlName="cd_nom"
-            placeholder="Nom latin ou vernaculaire ou cd_ref" [editable]="false"
+            placeholder="Nom latin ou vernaculaire ou cd_ref"
+            i18n-placeholder="Placeholder for species name input@@speciesNamePlaceholder"
+            [editable]="false"
             [ngbTypeahead]="inputAutoCompleteSearch" [resultTemplate]="rt"
             [inputFormatter]="inputAutoCompleteFormatter" />
     </div>
@@ -120,15 +125,15 @@
         <div class="form-check">
             <input type="checkbox" class="form-check-input" id="reportObserver" formControlName="report_observer"
                 checked (change)="true" />
-            <label class="form-check-label" style="margin-left: 5px; margin-bottom: 0;" for="reportObserver">
+            <label class="form-check-label" style="margin-left: 5px; margin-bottom: 0;" for="reportObserver" i18n="Label for notifying the observer@@notifyObserverLabel">
                 Avertir l'observateur
             </label>
-            <small class="form-text text-muted">L'observateur recevra un mail contenant des informations de validation,
+            <small class="form-text text-muted" i18n="Description for observer notification@@observerNotificationDescription">L'observateur recevra un mail contenant des informations de validation,
                 correction ou d'invalidité de son observation.</small>
         </div>
     </div>
     <div class="form-group col-lg-12 col-md-12">
-        <label>
+        <label  i18n="Label for unvalidable observation@@unvalidableObservationLabel">
             Si l'observation est non validable en l'état :
         </label>
         <div class="form-row">
@@ -138,17 +143,25 @@
                     <option *ngFor="let status of invalidationStatuses" [ngValue]="status.value">{{ status.text }}
                     </option>
                 </select>
-                <small class="form-text text-muted">Demander à l'observateur de modifier son observation ou a un autre
+                <small class="form-text text-muted"  i18n="Request for observer modification or validator check@@requestObserverModification">Demander à l'observateur de modifier son observation ou a un autre
                     validateur de la vérifier.</small>
             </div>
         </div>
     </div>
     <div class="modal-footer">
         <button type="submit" class="btn btn-big rounded-0"
-            [ngClass]="obsValidatable ? 'btn-default btn-outline-primary' : 'btn-warning btn-outline-warning bg-warning'"
-            i18n="Valid obs btn@@validObsBtn">
-            {{ obsValidatable ? (obsCorrection ? 'Corriger' : 'Valider') : 'Invalider' }} l'observation
+                    [ngClass]="obsValidatable ? 'btn-default btn-outline-primary' : 'btn-warning btn-outline-warning bg-warning'"
+                    i18n="Button for validating, correcting, or invalidating an observation@@obsActionBtn">
+            { obsValidatable, select,
+                true { { obsCorrection, select,
+                        true {Corriger l'observation}
+                        false {Valider l'observation}
+                        }
+                    }
+                false {Invalider l'observation}
+            }
         </button>
+
         <button type="button" class="btn btn-secondary btn-big rounded-0" (click)="cancelValidation()"
             i18n="Cancel@@cancel">
             Annuler

--- a/frontend/src/app/programs/sites/form/form.component.html
+++ b/frontend/src/app/programs/sites/form/form.component.html
@@ -1,6 +1,6 @@
 <div *ngIf="readyToDisplay">
     <div *ngIf="jsonSchema.steps">
-        <h3>
+        <h3 i18n="Step Title@@stepTitle">
             Etape {{ currentStep }}/{{ totalSteps() }} :
             {{ jsonSchema.steps[currentStep - 1].title }}
         </h3>
@@ -10,21 +10,21 @@
         <div class="row" [ngClass]="currentStep === 1 ? '' : 'hidden'">
             <div class="col-md-4">
                 <div class="input-group">
-                    <label for="date">Date de la visite</label>
+                    <label for="date" i18n="Visit Date@@visitDate">Date de la visite</label>
                     <input formControlName="date" type="text" class="form-control rounded-0" placeholder="yyyy-mm-dd"
                         ngbDatepicker #d="ngbDatepicker" (click)="d.toggle()" />
                     <div *ngIf="visitForm.get('date').invalid" class="alert alert-danger">
-                        <div *ngIf="visitForm.get('date').errors.required">
+                        <div *ngIf="visitForm.get('date').errors.required" i18n="Date Required@@dateRequired">
                             La date est obligatoire
                         </div>
                         <div *ngIf="
                                 visitForm.get('date').errors[
                                     'Parsed a date in the future'
                                 ]
-                            ">
+                            "  i18n="Message d'erreur pour une date future@@futureDateError">
                             La date doit être antérieure à la date du jour
                         </div>
-                        <div *ngIf="visitForm.get('date').errors.ngbDate">
+                        <div *ngIf="visitForm.get('date').errors.ngbDate"  i18n="Message d'erreur pour une date invalide@@invalidDateError">
                             Date invalide
                         </div>
                     </div>

--- a/frontend/src/app/programs/sites/list/list.component.html
+++ b/frontend/src/app/programs/sites/list/list.component.html
@@ -3,7 +3,7 @@
     <span [class.d-none]="display_form">
         <div class="d-flex flex-column">
             <div class="col-lg-12 mx-4 mt-2 mb-4">
-                <strong><span *ngIf="userDashboard">Mes </span>Sites </strong>
+                <strong><span *ngIf="userDashboard" i18n="Titre pour Mes Sites@@mySitesTitle">Mes Sites </span> </strong>
                 <span class="badge badge-pill badge-info">{{ sites?.length }}</span>
                 <ng-content select="[add-obs]"></ng-content>
             </div>
@@ -21,13 +21,14 @@
                                 &nbsp;
                                 <app-sitemodalflow #modalFlowRef [coords]="o.properties.coords"
                                     [updateData]="o.properties" [program_id]="o.properties.id_program">
-                                    <i class="fa fa-edit text-primary" placement="bottom" ngbTooltip="Editer" *ngIf="
+                                    <i class="fa fa-edit text-primary" placement="bottom" ngbTooltip="Editer" i18n-ngbTooltip="Tooltip for edit button@@editButtonTooltip"
+                                    *ngIf="
                                         o.properties.id_role ===
                                         userService.role_id
                                     " btn-open></i>
                                 </app-sitemodalflow>
                                 &nbsp;
-                                <i class="fa fa-trash text-danger" placement="bottom" ngbTooltip="Supprimer" (click)="
+                                <i class="fa fa-trash text-danger" placement="bottom" ngbTooltip="Supprimer" i18n-ngbTooltip="Tooltip for delete button@@deleteButtonTooltip" (click)="
                                     siteService.deleteSite.emit(
                                         o.properties.id_site
                                     )
@@ -37,13 +38,12 @@
                                 " owner-actions></i>
                             </span>
                         </h5>
-                        <p>
-                            {{ o.properties.site_type.type | titlecase }} ajouté(e)
-                            par
-                            <span>{{ o.properties.obs_txt }}</span>
+                        <p i18n="Message d'ajout@@addedMessage">
+                            <ng-container>{{ o.properties.site_type.type | titlecase }}</ng-container> ajouté(e) par <span>{{ o.properties.obs_txt }}</span>
                         </p>
+                          
                         <p>
-                            le
+                            <span i18n="Déterminant pour une date@@dateDeterminer">le</span>
                             <span>{{
                                 o.properties.timestamp_create.substring(0, 10)
                                 | date: 'longDate'

--- a/frontend/src/app/programs/sites/modalflow/steps/congrats/congrats.component.html
+++ b/frontend/src/app/programs/sites/modalflow/steps/congrats/congrats.component.html
@@ -1,6 +1,6 @@
 <!-- Observation ajoutée -->
 <div class="modal-body obs-added">
     <div></div>
-    <h5>Félicitations !</h5>
-    <h6>Votre site a bien été ajoutée !</h6>
+    <h5 i18n="Félicitations@@congratsTitle">Félicitations !</h5>
+    <h6 i18n="Message de félicitations@@congratsMessage">Votre site a bien été ajoutée !</h6>
 </div>

--- a/frontend/src/app/programs/sites/modalflow/steps/site/site_step.component.html
+++ b/frontend/src/app/programs/sites/modalflow/steps/site/site_step.component.html
@@ -1,6 +1,6 @@
 <!-- Ajouter une observation -->
 <div class="modal-header">
-    <h4 class="modal-title">AJOUTER UN SITE</h4>
+    <h4 class="modal-title" i18n="Title for add site@@addSiteTitle">AJOUTER UN SITE</h4>
     <button
         type="button"
         class="close"
@@ -25,6 +25,7 @@
         [disabled]="!form.siteForm.valid"
         class="btn btn-default btn-outline-primary rounded-0"
         (click)="committed()"
+        i18n="button valid site@@validSiteButton"
     >
         Valider le site
     </button>

--- a/frontend/src/app/programs/sites/modalflow/steps/visit/visit_step.component.html
+++ b/frontend/src/app/programs/sites/modalflow/steps/visit/visit_step.component.html
@@ -1,6 +1,6 @@
 <!-- Ajouter une observation -->
 <div class="modal-header">
-    <h4 class="modal-title">AJOUTER UN RAPPORT DE VISITE</h4>
+    <h4 class="modal-title"  i18n="Modal title for adding a site visit report@@addSiteVisitReportTitle">AJOUTER UN RAPPORT DE VISITE</h4>
     <button
         type="button"
         class="close"
@@ -24,6 +24,7 @@
         class="btn btn-danger rounded-0"
         (click)="form.previousStep()"
         *ngIf="!form.isFirstStep()"
+        i18n="Previous Step@@previousStep"
     >
         Etape précédente
     </button>
@@ -32,6 +33,7 @@
         (click)="form.nextStep()"
         *ngIf="!form.isLastStep()"
         [disabled]="form.invalidStep()"
+        i18n="Next Step@@nextStep"
     >
         Etape suivante
     </button>
@@ -41,6 +43,7 @@
         class="btn btn-default btn-outline-primary rounded-0"
         (click)="committed()"
         *ngIf="form.isLastStep()"
+        i18n="button valid visit@@validVisitButton"
     >
         Valider la visite
     </button>

--- a/frontend/src/app/programs/sites/siteform/siteform.component.html
+++ b/frontend/src/app/programs/sites/siteform/siteform.component.html
@@ -2,8 +2,10 @@
 
     <div class="form-row">
         <div class="form-group col-lg-12 col-md-12">
-            <h5>Informations</h5>
-            <label for="counting">*Type de site&nbsp;</label>
+            <h5 i18n="Informations@@informations">Informations</h5>
+            <label for="counting">
+            <span aria-hidden="true">*</span>
+            <span i18n="Libellé pour le champ Type de site@@siteTypeLabel">Type de site</span>&nbsp;</label>
             <select
                 type="text"
                 formControlName="id_type"
@@ -18,11 +20,14 @@
                     {{ t.text }}
                 </option>
             </select>
-            <label for="counting">*Nom du site&nbsp;</label>
+            <label for="counting">
+                <span aria-hidden="true">*</span>
+                <span i18n="Libellé pour le champ Nom du site@@siteNameLabel">Nom du site</span>&nbsp;
+              </label>
             <input type="text" formControlName="name" class="form-control" />
         </div>
-        <div class="form-group col-lg-12 col-md-12">
-            <h5>Où est-il situé ?</h5>
+        <div class="form-group col-lg-6 col-md-12 half">
+            <h5 i18n="Question localisation site@@locationSiteQuestion">Où est-il situé ?</h5>
             <div class="position-relative">
                 <div class="zoom-alert" *ngIf="hasZoomAlert">
                     <div class="mb-2 text-center" i18n="Zooming instruction@@zoomingInstruction">

--- a/frontend/src/app/programs/sites/sites.component.html
+++ b/frontend/src/app/programs/sites/sites.component.html
@@ -41,8 +41,8 @@
             <app-sites-list #sitesListRef [sites]="sites" [program_id]="program_id" [displayForm]="flowService.display"
                 [userDashboard]="userDashboard" (siteSelect)="sitesMapRef.showPopup($event)">
                 <button type="button" class="btn btn-success mr-4 float-right" add-obs (click)="addSiteClicked()"
-                    *ngIf="!userDashboard" ngbTooltip="Ajouter un site" placement="left">
-                    Ajouter
+                    *ngIf="!userDashboard" ngbTooltip="Ajouter un site" i18n-ngbTooltip="Tooltip for adding a site@@addSiteTooltip" placement="left">
+                    <span i18n="Add site button text@@addSiteButton">Ajouter</span>
                 </button>
                 <app-sitemodalflow #modalFlowRef [coords]="coords" [modalversion]="
                         MainConfig.FRONTEND.NEW_OBS_FORM_MODAL_VERSION
@@ -72,14 +72,14 @@
                         <app-sites-list #sitesListRef [sites]="sites" [program_id]="program_id"
                             [displayForm]="flowService.display" [userDashboard]="userDashboard"
                             (siteSelect)="sitesMapRef.showPopup($event)">
-                            <button type="button" class="btn btn-success mr-4" btn-open>
+                            <button type="button" class="btn btn-success mr-4" i18n="Add button text@@addButtonText" btn-open>
                                 Ajouter
                             </button>
                             <app-sitemodalflow #modalFlowRef [coords]="coords" [modalversion]="
                                     MainConfig.FRONTEND
                                         .NEW_OBS_FORM_MODAL_VERSION
                                 " [program_id]="program_id" class="float-right" obs-form>
-                                <button type="button" class="btn btn-success mr-4" btn-open>
+                                <button type="button" class="btn btn-success mr-4" btn-open i18n="Add button text@@addButtonText">
                                     Ajouter
                                 </button>
                             </app-sitemodalflow>

--- a/frontend/src/app/synthesis/species/species.component.html
+++ b/frontend/src/app/synthesis/species/species.component.html
@@ -17,7 +17,7 @@
                             <li>{{ taxon?.group2_inpn }}</li>
                             <li>{{ taxon?.regne }}</li>
                         </ul>
-                        <a target="_blank" [href]="taxon?.url" hreflang="fr" class="btn-big">Découvrir sur INPN</a>
+                        <a target="_blank" [href]="taxon?.url" hreflang="fr" class="btn-big" i18n="Link to INPN@@discoverINPN">Découvrir sur INPN</a>
                     </div>
                 </div>
             </div>

--- a/frontend/src/conf/app.config.ts.template
+++ b/frontend/src/conf/app.config.ts.template
@@ -23,40 +23,49 @@ export const AppConfig = {
     // termsOfUse: {
     //     fr: 'assets/cgu.pdf',
     //     en: 'assets/termsOfUse.pdf',
+    //     de: 'assets/nutzungsbedingungen.pdf',
     // },
     // signup: 'optional', // never|optional|always
     // email_contact: false,
     // platform_intro: {
     //     fr: 'Bienvenue<br /> sur GeoNature Citizen',
     //     en: 'Welcome<br /> on GeoNature Citizen',
+    //     de: 'Willkommen<br /> bei GeoNature Citizen',
     // },
     // platform_teaser: {
     //     fr: 'Hae duae provinciae bello quondam piratico catervis mixtae praedonum a Servilio pro consule missae sub iugum factae sunt vectigales. et hae quidem regiones velut in prominenti terrarum lingua positae ob orbe eoo monte Amano disparantur.',
     //     en: 'Hae duae provinciae bello quondam piratico catervis mixtae praedonum a Servilio pro consule missae sub iugum factae sunt vectigales. et hae quidem regiones velut in prominenti terrarum lingua positae ob orbe eoo monte Amano disparantur.',
+    //     de: 'Diese beiden Provinzen wurden einst durch den Piratenkrieg mit Banden von Räubern vermischt und von Servilius, dem Prokonsul, unterjocht und steuerpflichtig gemacht.',
     // },
     // platform_participate: {
     //     fr: 'PARTICIPER AU PROGRAMME',
     //     en: 'PARTICIPATE',
+    //     de: 'AM PROGRAMM TEILNEHMEN',
     // },
     // programs_label: {
     //     fr: 'Programmes',
     //     en: 'Surveys',
+    //     de: 'Programme',
     // },
     // program_label: {
     //     fr: 'Le programme',
     //     en: 'Survey',
+    //     de: 'Das Programm',
     // },
     // program_share_an_observation: {
     //     fr: 'PARTAGER UNE OBSERVATION',
     //     en: 'SHARE AN OBSERVATION',
+    //     de: 'EINE BEOBACHTUNG TEILEN',
     // },
     // program_add_an_observation: {
     //     fr: 'AJOUTER UNE OBSERVATION',
     //     en: 'CONTRIBUTE AN OBSERVATION',
+    //     de: 'EINE BEOBACHTUNG HINZUFÜGEN',
     // },
     // program_allow_email_contact: {
     //     fr: "J'accepte que mon adresse e-mail puisse être utilisée pour recontacter à propos de mon observation",
     //     en: 'I agree that my e-mail address can be used to recontact about my observation',
+    //     de: 'Ich stimme zu, dass meine E-Mail-Adresse zur Kontaktaufnahme bezüglich meiner Beobachtung verwendet werden kann.',
     // },
     // taxonDisplayImageWhenUnique: true,
     // taxonSelectInputThreshold: 7,

--- a/frontend/src/conf/map.config.ts.template
+++ b/frontend/src/conf/map.config.ts.template
@@ -87,6 +87,7 @@ export const MAP_CONFIG = {
     // OBS_POINTER: 'assets/pointer-green.png',
     // LOCATE_CONTROL_TITLE: {
     //     fr: 'Me localiser',
-    //     en: 'Show me where i am',
+    //     en: 'Show me where I am',
+    //     de: 'Zeig mir, wo ich bin',
     // },
 };

--- a/frontend/src/i18n/messages.de.xlf
+++ b/frontend/src/i18n/messages.de.xlf
@@ -1,30 +1,30 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-  <file source-language="fr" datatype="plaintext" original="ng2.template">
+  <file source-language="fr" datatype="plaintext" original="ng2.template" target-language="de">
     <body>
       <trans-unit id="ngb.alert.close" datatype="html">
-        <source>Close</source>
+        <source>Close</source><target state="new">Schließen</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../node_modules/@ng-bootstrap/ng-bootstrap/alert/alert.d.ts</context>
           <context context-type="linenumber">3</context>
         </context-group>
       </trans-unit>
       <trans-unit id="ngb.carousel.previous" datatype="html">
-        <source>Previous</source>
+        <source>Previous</source><target state="new">Zurück</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../node_modules/@ng-bootstrap/ng-bootstrap/carousel/carousel.d.ts</context>
           <context context-type="linenumber">13</context>
         </context-group>
       </trans-unit>
       <trans-unit id="ngb.carousel.next" datatype="html">
-        <source>Next</source>
+        <source>Next</source><target state="new">Weiter</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../node_modules/@ng-bootstrap/ng-bootstrap/carousel/carousel.d.ts</context>
           <context context-type="linenumber">17</context>
         </context-group>
       </trans-unit>
       <trans-unit id="ngb.datepicker.previous-month" datatype="html">
-        <source>Previous month</source>
+        <source>Previous month</source><target state="new">Vorheriger Monat</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../node_modules/@ng-bootstrap/ng-bootstrap/datepicker/datepicker-navigation.d.ts</context>
           <context context-type="linenumber">4</context>
@@ -35,7 +35,7 @@
         </context-group>
       </trans-unit>
       <trans-unit id="ngb.datepicker.next-month" datatype="html">
-        <source>Next month</source>
+        <source>Next month</source><target state="new">Nächster Monat</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../node_modules/@ng-bootstrap/ng-bootstrap/datepicker/datepicker-navigation.d.ts</context>
           <context context-type="linenumber">26</context>
@@ -46,7 +46,7 @@
         </context-group>
       </trans-unit>
       <trans-unit id="ngb.datepicker.select-month" datatype="html">
-        <source>Select month</source>
+        <source>Select month</source><target state="new">Monat auswählen</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../node_modules/@ng-bootstrap/ng-bootstrap/datepicker/datepicker-navigation-select.d.ts</context>
           <context context-type="linenumber">5</context>
@@ -57,7 +57,7 @@
         </context-group>
       </trans-unit>
       <trans-unit id="ngb.datepicker.select-year" datatype="html">
-        <source>Select year</source>
+        <source>Select year</source><target state="new">Jahr auswählen</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../node_modules/@ng-bootstrap/ng-bootstrap/datepicker/datepicker-navigation-select.d.ts</context>
           <context context-type="linenumber">13</context>
@@ -68,175 +68,175 @@
         </context-group>
       </trans-unit>
       <trans-unit id="ngb.pagination.first" datatype="html">
-        <source>««</source>
+        <source>««</source><target state="new">««</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../node_modules/@ng-bootstrap/ng-bootstrap/pagination/pagination.d.ts</context>
           <context context-type="linenumber">2</context>
         </context-group>
       </trans-unit>
       <trans-unit id="ngb.pagination.previous" datatype="html">
-        <source>«</source>
+        <source>«</source><target state="new">«</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../node_modules/@ng-bootstrap/ng-bootstrap/pagination/pagination.d.ts</context>
           <context context-type="linenumber">3</context>
         </context-group>
       </trans-unit>
       <trans-unit id="ngb.pagination.next" datatype="html">
-        <source>»</source>
+        <source>»</source><target state="new">»</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../node_modules/@ng-bootstrap/ng-bootstrap/pagination/pagination.d.ts</context>
           <context context-type="linenumber">4</context>
         </context-group>
       </trans-unit>
       <trans-unit id="ngb.pagination.last" datatype="html">
-        <source>»»</source>
+        <source>»»</source><target state="new">»»</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../node_modules/@ng-bootstrap/ng-bootstrap/pagination/pagination.d.ts</context>
           <context context-type="linenumber">5</context>
         </context-group>
       </trans-unit>
       <trans-unit id="ngb.pagination.first-aria" datatype="html">
-        <source>First</source>
+        <source>First</source><target state="new">Erste</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../node_modules/@ng-bootstrap/ng-bootstrap/pagination/pagination.d.ts</context>
           <context context-type="linenumber">14</context>
         </context-group>
       </trans-unit>
       <trans-unit id="ngb.pagination.previous-aria" datatype="html">
-        <source>Previous</source>
+        <source>Previous</source><target state="new">Zurück</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../node_modules/@ng-bootstrap/ng-bootstrap/pagination/pagination.d.ts</context>
           <context context-type="linenumber">24</context>
         </context-group>
       </trans-unit>
       <trans-unit id="ngb.pagination.next-aria" datatype="html">
-        <source>Next</source>
+        <source>Next</source><target state="new">Weiter</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../node_modules/@ng-bootstrap/ng-bootstrap/pagination/pagination.d.ts</context>
           <context context-type="linenumber">44</context>
         </context-group>
       </trans-unit>
       <trans-unit id="ngb.pagination.last-aria" datatype="html">
-        <source>Last</source>
+        <source>Last</source><target state="new">Letzte</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../node_modules/@ng-bootstrap/ng-bootstrap/pagination/pagination.d.ts</context>
           <context context-type="linenumber">53</context>
         </context-group>
       </trans-unit>
       <trans-unit id="ngb.progressbar.value" datatype="html">
-        <source><x id="INTERPOLATION" equiv-text="{{getPercentValue()}}"/>%</source>
+        <source><x id="INTERPOLATION" equiv-text="{{getPercentValue()}}"/>%</source><target state="new"><x id="INTERPOLATION" equiv-text="{{getPercentValue()}}"/>%</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../node_modules/@ng-bootstrap/ng-bootstrap/progressbar/progressbar.d.ts</context>
           <context context-type="linenumber">6</context>
         </context-group>
       </trans-unit>
       <trans-unit id="ngb.timepicker.increment-hours" datatype="html">
-        <source>Increment hours</source>
+        <source>Increment hours</source><target state="new">Stunden erhöhen</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../node_modules/@ng-bootstrap/ng-bootstrap/timepicker/timepicker.d.ts</context>
           <context context-type="linenumber">9</context>
         </context-group>
       </trans-unit>
       <trans-unit id="ngb.timepicker.HH" datatype="html">
-        <source>HH</source>
+        <source>HH</source><target state="new">HH</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../node_modules/@ng-bootstrap/ng-bootstrap/timepicker/timepicker.d.ts</context>
           <context context-type="linenumber">13</context>
         </context-group>
       </trans-unit>
       <trans-unit id="ngb.timepicker.hours" datatype="html">
-        <source>Hours</source>
+        <source>Hours</source><target state="new">Stunden</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../node_modules/@ng-bootstrap/ng-bootstrap/timepicker/timepicker.d.ts</context>
           <context context-type="linenumber">15</context>
         </context-group>
       </trans-unit>
       <trans-unit id="ngb.timepicker.decrement-hours" datatype="html">
-        <source>Decrement hours</source>
+        <source>Decrement hours</source><target state="new">Stunden verringern</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../node_modules/@ng-bootstrap/ng-bootstrap/timepicker/timepicker.d.ts</context>
           <context context-type="linenumber">23</context>
         </context-group>
       </trans-unit>
       <trans-unit id="ngb.timepicker.increment-minutes" datatype="html">
-        <source>Increment minutes</source>
+        <source>Increment minutes</source><target state="new">Minuten erhöhen</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../node_modules/@ng-bootstrap/ng-bootstrap/timepicker/timepicker.d.ts</context>
           <context context-type="linenumber">32</context>
         </context-group>
       </trans-unit>
       <trans-unit id="ngb.timepicker.MM" datatype="html">
-        <source>MM</source>
+        <source>MM</source><target state="new">MM</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../node_modules/@ng-bootstrap/ng-bootstrap/timepicker/timepicker.d.ts</context>
           <context context-type="linenumber">35</context>
         </context-group>
       </trans-unit>
       <trans-unit id="ngb.timepicker.minutes" datatype="html">
-        <source>Minutes</source>
+        <source>Minutes</source><target state="new">Minuten</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../node_modules/@ng-bootstrap/ng-bootstrap/timepicker/timepicker.d.ts</context>
           <context context-type="linenumber">37</context>
         </context-group>
       </trans-unit>
       <trans-unit id="ngb.timepicker.decrement-minutes" datatype="html">
-        <source>Decrement minutes</source>
+        <source>Decrement minutes</source><target state="new">Minuten verringern</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../node_modules/@ng-bootstrap/ng-bootstrap/timepicker/timepicker.d.ts</context>
           <context context-type="linenumber">45</context>
         </context-group>
       </trans-unit>
       <trans-unit id="ngb.timepicker.increment-seconds" datatype="html">
-        <source>Increment seconds</source>
+        <source>Increment seconds</source><target state="new">Sekunden erhöhen</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../node_modules/@ng-bootstrap/ng-bootstrap/timepicker/timepicker.d.ts</context>
           <context context-type="linenumber">54</context>
         </context-group>
       </trans-unit>
       <trans-unit id="ngb.timepicker.SS" datatype="html">
-        <source>SS</source>
+        <source>SS</source><target state="new">SS</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../node_modules/@ng-bootstrap/ng-bootstrap/timepicker/timepicker.d.ts</context>
           <context context-type="linenumber">57</context>
         </context-group>
       </trans-unit>
       <trans-unit id="ngb.timepicker.seconds" datatype="html">
-        <source>Seconds</source>
+        <source>Seconds</source><target state="new">Sekunden</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../node_modules/@ng-bootstrap/ng-bootstrap/timepicker/timepicker.d.ts</context>
           <context context-type="linenumber">59</context>
         </context-group>
       </trans-unit>
       <trans-unit id="ngb.timepicker.decrement-seconds" datatype="html">
-        <source>Decrement seconds</source>
+        <source>Decrement seconds</source><target state="new">Sekunden verringern</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../node_modules/@ng-bootstrap/ng-bootstrap/timepicker/timepicker.d.ts</context>
           <context context-type="linenumber">67</context>
         </context-group>
       </trans-unit>
       <trans-unit id="ngb.timepicker.PM" datatype="html">
-        <source><x id="INTERPOLATION" equiv-text="{{ i18n.getAfternoonPeriod() }}"/></source>
+        <source><x id="INTERPOLATION" equiv-text="{{ i18n.getAfternoonPeriod() }}"/></source><target state="new"><x id="INTERPOLATION" equiv-text="{{ i18n.getAfternoonPeriod() }}"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">../node_modules/@ng-bootstrap/ng-bootstrap/timepicker/timepicker.d.ts</context>
           <context context-type="linenumber">75</context>
         </context-group>
       </trans-unit>
       <trans-unit id="ngb.timepicker.AM" datatype="html">
-        <source><x id="INTERPOLATION" equiv-text="{{ i18n.getMorningPeriod() }}"/></source>
+        <source><x id="INTERPOLATION" equiv-text="{{ i18n.getMorningPeriod() }}"/></source><target state="new"><x id="INTERPOLATION" equiv-text="{{ i18n.getMorningPeriod() }}"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">../node_modules/@ng-bootstrap/ng-bootstrap/timepicker/timepicker.d.ts</context>
           <context context-type="linenumber">76</context>
         </context-group>
       </trans-unit>
       <trans-unit id="ngb.toast.close-aria" datatype="html">
-        <source>Close</source>
+        <source>Close</source><target state="new">Schließen</target>
         <context-group purpose="location">
           <context context-type="sourcefile">../node_modules/@ng-bootstrap/ng-bootstrap/toast/toast.d.ts</context>
           <context context-type="linenumber">8</context>
         </context-group>
       </trans-unit>
       <trans-unit id="register" datatype="html">
-        <source>Créez votre compte</source>
+        <source>Créez votre compte</source><target state="new">Konto erstellen</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/auth/register/register.component.html</context>
           <context context-type="linenumber">2</context>
@@ -250,7 +250,9 @@
       <trans-unit id="emailNotValid" datatype="html">
         <source>
             Impossible de valider votre email.
-        </source>
+        </source><target state="new">
+            Ihre E-Mail konnte nicht validiert werden.
+        </target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/auth/register/register.component.html</context>
           <context context-type="linenumber">15</context>
@@ -258,19 +260,13 @@
         <note priority="1" from="description">Unable to valid email</note>
       </trans-unit>
       <trans-unit id="yourUsernameLabel" datatype="html">
-        <source>Votre pseudonyme</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/auth/register/register.component.html</context>
-          <context context-type="linenumber">33</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context>
-          <context context-type="linenumber">136</context>
-        </context-group>
+        <source>Votre pseudonyme</source><target state="new">Ihr Benutzername</target>
+        
+        
         <note priority="1" from="description">Your pseudo</note>
-      </trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/auth/register/register.component.html</context><context context-type="linenumber">33</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">136</context></context-group></trans-unit>
       <trans-unit id="yourUsernameInputPlaceHolder" datatype="html">
-        <source>Entrez votre pseudonyme</source>
+        <source>Entrez votre pseudonyme</source><target state="new">Geben Sie Ihren Benutzernamen ein</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/auth/register/register.component.html</context>
           <context context-type="linenumber">40</context>
@@ -278,7 +274,7 @@
         <note priority="1" from="description">Enter your pseudo</note>
       </trans-unit>
       <trans-unit id="yourEmailLabel" datatype="html">
-        <source>Votre email</source>
+        <source>Votre email</source><target state="new">Ihre E-Mail</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/auth/register/register.component.html</context>
           <context context-type="linenumber">47</context>
@@ -286,19 +282,13 @@
         <note priority="1" from="description">Your email form label</note>
       </trans-unit>
       <trans-unit id="yourEmailInputPlaceholder" datatype="html">
-        <source>Entrez votre email</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/auth/register/register.component.html</context>
-          <context context-type="linenumber">54</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context>
-          <context context-type="linenumber">159</context>
-        </context-group>
+        <source>Entrez votre email</source><target state="new">Geben Sie Ihre E-Mail ein</target>
+        
+        
         <note priority="1" from="description">Your email input placeholder label</note>
-      </trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/auth/register/register.component.html</context><context context-type="linenumber">54</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">159</context></context-group></trans-unit>
       <trans-unit id="yourFirstNameLabel" datatype="html">
-        <source>Votre prénom</source>
+        <source>Votre prénom</source><target state="new">Ihr Vorname</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/auth/register/register.component.html</context>
           <context context-type="linenumber">64</context>
@@ -310,7 +300,7 @@
         <note priority="1" from="description">your first name</note>
       </trans-unit>
       <trans-unit id="yourLastNameLabel" datatype="html">
-        <source>Votre nom</source>
+        <source>Votre nom</source><target state="new">Ihr Nachname</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/auth/register/register.component.html</context>
           <context context-type="linenumber">72</context>
@@ -318,7 +308,7 @@
         <note priority="1" from="description">your last name label</note>
       </trans-unit>
       <trans-unit id="yourLastNameInput" datatype="html">
-        <source>Entrez votre nom</source>
+        <source>Entrez votre nom</source><target state="new">Geben Sie Ihren Nachnamen ein</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/auth/register/register.component.html</context>
           <context context-type="linenumber">74</context>
@@ -328,7 +318,9 @@
       <trans-unit id="ErrorPasswordNotEnoughStrong" datatype="html">
         <source>
                 Doit contenir au moins un chiffre et une lettre majuscule et minuscule, et au moins 8 caractères.
-            </source>
+            </source><target state="new">
+                Muss mindestens eine Zahl und einen Groß- und Kleinbuchstaben enthalten und mindestens 8 Zeichen lang sein.
+            </target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/auth/register/register.component.html</context>
           <context context-type="linenumber">81</context>
@@ -338,7 +330,9 @@
       <trans-unit id="ErrorDifferentPasswords" datatype="html">
         <source>
                 Les mots de passe diffèrent.
-            </source>
+            </source><target state="new">
+                Die Passwörter stimmen nicht überein.
+            </target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/auth/register/register.component.html</context>
           <context context-type="linenumber">85</context>
@@ -346,7 +340,7 @@
         <note priority="1" from="description">Different password error</note>
       </trans-unit>
       <trans-unit id="yourPasswordInputLabel" datatype="html">
-        <source>Votre mot de passe</source>
+        <source>Votre mot de passe</source><target state="new">Ihr Passwort</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/auth/register/register.component.html</context>
           <context context-type="linenumber">92</context>
@@ -354,7 +348,7 @@
         <note priority="1" from="description">Your password label</note>
       </trans-unit>
       <trans-unit id="yourPasswordInput" datatype="html">
-        <source>Votre mot de passe</source>
+        <source>Votre mot de passe</source><target state="new">Ihr Passwort</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/auth/register/register.component.html</context>
           <context context-type="linenumber">94</context>
@@ -362,24 +356,25 @@
         <note priority="1" from="description">Your password input</note>
       </trans-unit>
       <trans-unit id="83c243fb33445d5db02ab9f9d8df7ee59553c324" datatype="html">
-        <source>Confirmez votre mot de passe</source>
+        <source>Confirmez votre mot de passe</source><target state="new">Bestätigen Sie Ihr Passwort</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/auth/register/register.component.html</context>
           <context context-type="linenumber">101</context>
         </context-group>
       </trans-unit>
       <trans-unit id="yourPasswordConfirmInput" datatype="html">
-        <source>Confirmez le mot de passe</source>
+        <source>Confirmez le mot de passe</source><target state="new">Bestätigen Sie das Passwort</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/auth/register/register.component.html</context>
           <context context-type="linenumber">105</context>
         </context-group>
         <note priority="1" from="description">Your confirm password input</note>
-      </trans-unit>
-      <trans-unit id="invalidPasswordError" datatype="html">
+      </trans-unit><trans-unit id="invalidPasswordError" datatype="html">
         <source>
-                        S&apos;il vous plait entrez un mot de passe valide.
-                    </source>
+                        S'il vous plait entrez un mot de passe valide.
+                    </source><target state="new">
+                        Bitte geben Sie eine gültige Stadt an.
+                    </target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/auth/register/register.component.html</context>
           <context context-type="linenumber">107</context>
@@ -388,24 +383,22 @@
       </trans-unit>
       <trans-unit id="acceptUGC" datatype="html">
         <source>
-                    Veuillez accepter les conditions d&apos;utilisation.
-                </source>
+                    Veuillez accepter les conditions d'utilisation.
+                </source><target state="new">
+                    Bitte akzeptieren Sie die Nutzungsbedingungen.
+                </target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/auth/register/register.component.html</context>
           <context context-type="linenumber">114</context>
         </context-group>
         <note priority="1" from="description">Accept UGC</note>
-      </trans-unit>
-      <trans-unit id="iAcceptIntro" datatype="html">
-        <source>J&apos;accepte les </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/auth/register/register.component.html</context>
-          <context context-type="linenumber">119</context>
-        </context-group>
+      </trans-unit><trans-unit id="iAcceptIntro" datatype="html">
+        <source>J'accepte les</source><target state="new">Ich akzeptiere die</target>
+        
         <note priority="1" from="description">I Accept</note>
-      </trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/auth/register/register.component.html</context><context context-type="linenumber">119</context></context-group></trans-unit>
       <trans-unit id="conditionsOfUse" datatype="html">
-        <source>conditions d&apos;utilisation</source>
+        <source>conditions d'utilisation</source><target state="new">Nutzungsbedingungen</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/auth/register/register.component.html</context>
           <context context-type="linenumber">121</context>
@@ -414,42 +407,26 @@
       </trans-unit>
       <trans-unit id="registerLink" datatype="html">
         <source>
-            S&apos;enregistrer
-        </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/auth/register/register.component.html</context>
-          <context context-type="linenumber">133</context>
-        </context-group>
+            S'enregistrer
+        </source><target state="new">
+            Registrieren
+        </target>
+        
         <note priority="1" from="description">register link</note>
-      </trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/auth/register/register.component.html</context><context context-type="linenumber">133</context></context-group></trans-unit>
       <trans-unit id="closeModal" datatype="html">
         <source>
         Fermer
-    </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/auth/register/register.component.html</context>
-          <context context-type="linenumber">138</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/auth/login/login.component.html</context>
-          <context context-type="linenumber">163</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/programs/media-galery/media-galery.component.html</context>
-          <context context-type="linenumber">50</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
-          <context context-type="linenumber">172</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
-          <context context-type="linenumber">172</context>
-        </context-group>
+    </source><target state="new">
+        Schließen
+    </target>
+        
+        
+        
         <note priority="1" from="description">close modal</note>
-      </trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/auth/register/register.component.html</context><context context-type="linenumber">138</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/auth/login/login.component.html</context><context context-type="linenumber">163</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/programs/media-galery/media-galery.component.html</context><context context-type="linenumber">50</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/programs/base/detail/detail.component.html</context><context context-type="linenumber">172</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/programs/base/detail/detail.component.html</context><context context-type="linenumber">172</context></context-group></trans-unit>
       <trans-unit id="login" datatype="html">
-        <source>Se connecter</source>
+        <source>Se connecter</source><target state="new">Sich anmelden</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/auth/login/login.component.html</context>
           <context context-type="linenumber">2</context>
@@ -465,7 +442,7 @@
         <note priority="1" from="description">login</note>
       </trans-unit>
       <trans-unit id="yourEmail" datatype="html">
-        <source>Votre Email</source>
+        <source>Votre Email</source><target state="new">Ihre E-Mail</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/auth/login/login.component.html</context>
           <context context-type="linenumber">32</context>
@@ -473,7 +450,7 @@
         <note priority="1" from="description">Your email</note>
       </trans-unit>
       <trans-unit id="emailInput" datatype="html">
-        <source>Entrez votre email</source>
+        <source>Entrez votre email</source><target state="new">Geben Sie Ihre E-Mail ein</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/auth/login/login.component.html</context>
           <context context-type="linenumber">49</context>
@@ -487,7 +464,9 @@
       <trans-unit id="recoverAccount" datatype="html">
         <source>
             Récupérer le compte
-        </source>
+        </source><target state="new">
+            Konto wiederherstellen
+        </target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/auth/login/login.component.html</context>
           <context context-type="linenumber">65</context>
@@ -495,7 +474,7 @@
         <note priority="1" from="description">Recover account</note>
       </trans-unit>
       <trans-unit id="emailOrUsernameInputLabel" datatype="html">
-        <source>Email ou pseudo</source>
+        <source>Email ou pseudo</source><target state="new">E-Mail oder Benutzername</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/auth/login/login.component.html</context>
           <context context-type="linenumber">79</context>
@@ -503,7 +482,7 @@
         <note priority="1" from="description">email or username</note>
       </trans-unit>
       <trans-unit id="passwordLabel" datatype="html">
-        <source>Mot de passe</source>
+        <source>Mot de passe</source><target state="new">Passwort</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/auth/login/login.component.html</context>
           <context context-type="linenumber">110</context>
@@ -511,7 +490,7 @@
         <note priority="1" from="description">Password input label</note>
       </trans-unit>
       <trans-unit id="passwordInput" datatype="html">
-        <source>Entrez votre mot de passe</source>
+        <source>Entrez votre mot de passe</source><target state="new">Geben Sie Ihr Passwort ein</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/auth/login/login.component.html</context>
           <context context-type="linenumber">127</context>
@@ -519,7 +498,7 @@
         <note priority="1" from="description">Password input</note>
       </trans-unit>
       <trans-unit id="forgottenPasswordLink" datatype="html">
-        <source>Mot de passe oublié ?</source>
+        <source>Mot de passe oublié ?</source><target state="new">Passwort vergessen?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/auth/login/login.component.html</context>
           <context context-type="linenumber">141</context>
@@ -527,7 +506,7 @@
         <note priority="1" from="description">Forgotten password link</note>
       </trans-unit>
       <trans-unit id="addNewObs" datatype="html">
-        <source>AJOUTER UNE OBSERVATION</source>
+        <source>AJOUTER UNE OBSERVATION</source><target state="new">EINE BEOBACHTUNG HINZUFÜGEN</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/observations/modalflow/steps/onboard/onboard.component.html</context>
           <context context-type="linenumber">2</context>
@@ -537,9 +516,8 @@
           <context context-type="linenumber">3</context>
         </context-group>
         <note priority="1" from="description">Add new obs</note>
-      </trans-unit>
-      <trans-unit id="whyRegisterHeading" datatype="html">
-        <source>Pourquoi s&apos;inscrire ?</source>
+      </trans-unit><trans-unit id="whyRegisterHeading" datatype="html">
+        <source>Pourquoi s'inscrire ?</source><target state="new">Warum registrieren ?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/observations/modalflow/steps/onboard/onboard.component.html</context>
           <context context-type="linenumber">14</context>
@@ -547,7 +525,7 @@
         <note priority="1" from="description">Heading for why to register</note>
       </trans-unit>
       <trans-unit id="registerAndContribute" datatype="html">
-        <source>S&apos;incrire <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/&gt;"/>et contribuer au site</source>
+        <source>S'incrire <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/>"/>et contribuer au site</source><target state="new">Registrieren <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/>"/>und zur Website beitragen</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/observations/modalflow/steps/onboard/onboard.component.html</context>
           <context context-type="linenumber">24</context>
@@ -555,7 +533,7 @@
         <note priority="1" from="description">register and contribute</note>
       </trans-unit>
       <trans-unit id="continueUnregistered" datatype="html">
-        <source>Continuer <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/&gt;"/>sans s&apos;enregistrer</source>
+        <source>Continuer <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/>"/>sans s'enregistrer</source><target state="new">Weiter <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/>"/>ohne sich zu registrieren</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/observations/modalflow/steps/onboard/onboard.component.html</context>
           <context context-type="linenumber">30</context>
@@ -565,23 +543,23 @@
       <trans-unit id="inviteToLogin" datatype="html">
         <source>Vous
         avez déjà un compte ?
-        Connectez-vous !</source>
+        Connectez-vous !</source><target state="new">Sie
+        haben bereits ein Konto?
+        Melden Sie sich an!</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/observations/modalflow/steps/onboard/onboard.component.html</context>
           <context context-type="linenumber">36</context>
         </context-group>
         <note priority="1" from="description">Invite to login</note>
-      </trans-unit>
-      <trans-unit id="speciesSearchSelectionLabel" datatype="html">
-        <source>{VAR_SELECT, select, isOn {Rechercher une espèce} isOff {Sélectionnez une espèce} }</source>
+      </trans-unit><trans-unit id="speciesSearchSelectionLabel" datatype="html">
+        <source>{VAR_SELECT, select, isOn {Rechercher une espèce} isOff {Sélectionnez une espèce} }</source><target state="new">{VAR_SELECT, select, isOn {Eine Art suchen} isOff {Wählen Sie eine Art} }</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/observations/form/form.component.html</context>
           <context context-type="linenumber">26</context>
         </context-group>
         <note priority="1" from="description">Label for species search and selection</note>
-      </trans-unit>
-      <trans-unit id="chooseSpeciesOption" datatype="html">
-        <source>Choisissez une espèce</source>
+      </trans-unit><trans-unit id="chooseSpeciesOption" datatype="html">
+        <source>Choisissez une espèce</source><target state="new">Wählen Sie eine Art</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/observations/form/form.component.html</context>
           <context context-type="linenumber">37</context>
@@ -591,9 +569,8 @@
           <context context-type="linenumber">49</context>
         </context-group>
         <note priority="1" from="description">Option to choose a species</note>
-      </trans-unit>
-      <trans-unit id="speciesNamePlaceholder" datatype="html">
-        <source>Nom latin ou vernaculaire ou cd_ref</source>
+      </trans-unit><trans-unit id="speciesNamePlaceholder" datatype="html">
+        <source>Nom latin ou vernaculaire ou cd_ref</source><target state="new">Lateinischer oder gebräuchlicher Name oder cd_ref</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/observations/form/form.component.html</context>
           <context context-type="linenumber">83</context>
@@ -607,218 +584,187 @@
       <trans-unit id="additionalInfos" datatype="html">
         <source>
                 Informations complémentaires
-            </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/programs/observations/form/form.component.html</context>
-          <context context-type="linenumber">93</context>
-        </context-group>
+            </source><target state="new">
+                Zusätzliche Informationen
+            </target>
+        
         <note priority="1" from="description">Additional information</note>
-      </trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">93</context></context-group></trans-unit>
       <trans-unit id="bservationDate" datatype="html">
-        <source>Date de l&apos;observation</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/programs/observations/form/form.component.html</context>
-          <context context-type="linenumber">99</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/programs/observations/validation/validation.component.html</context>
-          <context context-type="linenumber">104</context>
-        </context-group>
+        <source>Date de l'observation</source><target state="new">Beobachtungsdatum</target>
+        
+        
         <note priority="1" from="description">observation date</note>
-      </trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">99</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/programs/observations/validation/validation.component.html</context><context context-type="linenumber">104</context></context-group></trans-unit>
       <trans-unit id="expectedDateFormat" datatype="html">
-        <source>jj/mm/aaaa</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/programs/observations/form/form.component.html</context>
-          <context context-type="linenumber">101</context>
-        </context-group>
+        <source>jj/mm/aaaa</source><target state="new">tt/mm/jjjj</target>
+        
         <note priority="1" from="description">
                                 expected date format</note>
-      </trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">101</context></context-group></trans-unit>
       <trans-unit id="enumerationInputLabel" datatype="html">
-        <source>Dénombrement</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/programs/observations/form/form.component.html</context>
-          <context context-type="linenumber">106</context>
-        </context-group>
+        <source>Dénombrement</source><target state="new">Zählung</target>
+        
         <note priority="1" from="description">Enumeration Label</note>
-      </trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">106</context></context-group></trans-unit>
       <trans-unit id="enumerationInputPlaceHolder" datatype="html">
-        <source>Nombre</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/programs/observations/form/form.component.html</context>
-          <context context-type="linenumber">108</context>
-        </context-group>
+        <source>Nombre</source><target state="new">Anzahl</target>
+        
         <note priority="1" from="description">
                             Enumeration Placeholder</note>
-      </trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">108</context></context-group></trans-unit>
       <trans-unit id="commentInputLabel" datatype="html">
-        <source>Commentaire</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/programs/observations/form/form.component.html</context>
-          <context context-type="linenumber">119</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/programs/observations/validation/validation.component.html</context>
-          <context context-type="linenumber">118</context>
-        </context-group>
+        <source>Commentaire</source><target state="new">Kommentar</target>
+        
+        
         <note priority="1" from="description">Comment Input Label</note>
-      </trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">119</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/programs/observations/validation/validation.component.html</context><context context-type="linenumber">118</context></context-group></trans-unit>
       <trans-unit id="commentInputPlaceholder" datatype="html">
-        <source>Votre commentaire</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/programs/observations/form/form.component.html</context>
-          <context context-type="linenumber">121</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/programs/observations/validation/validation.component.html</context>
-          <context context-type="linenumber">121</context>
-        </context-group>
+        <source>Votre commentaire</source><target state="new">Ihr Kommentar</target>
+        
+        
         <note priority="1" from="description">
                         Comment Input Placeholder</note>
-      </trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">121</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/programs/observations/validation/validation.component.html</context><context context-type="linenumber">121</context></context-group></trans-unit>
       <trans-unit id="existingPhotos" datatype="html">
-        <source>Photos existantes (cocher pour supprimer)</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/programs/observations/form/form.component.html</context>
-          <context context-type="linenumber">126</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/programs/sites/form/form.component.html</context>
-          <context context-type="linenumber">35</context>
-        </context-group>
+        <source>Photos existantes (cocher pour supprimer)</source><target state="new">Vorhandene Fotos (zum Löschen ankreuzen)</target>
+        
+        
         <note priority="1" from="description">Existing Photos</note>
-      </trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">126</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/programs/sites/form/form.component.html</context><context context-type="linenumber">35</context></context-group></trans-unit>
       <trans-unit id="addPhoto" datatype="html">
-        <source>Ajouter une photo</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/programs/observations/form/form.component.html</context>
-          <context context-type="linenumber">134</context>
-        </context-group>
+        <source>Ajouter une photo</source><target state="new">Ein Foto hinzufügen</target>
+        
         <note priority="1" from="description">Add photo</note>
-      </trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">134</context></context-group></trans-unit>
       <trans-unit id="obsLocation" datatype="html">
         <source>
                 Où avez-vous observé cette espèce ?
-            </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/programs/observations/form/form.component.html</context>
-          <context context-type="linenumber">142</context>
-        </context-group>
+            </source><target state="new">
+                Wo haben Sie diese Art beobachtet?
+            </target>
+        
         <note priority="1" from="description">observation Location</note>
-      </trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">142</context></context-group></trans-unit>
       <trans-unit id="ZoomToPointInstruction" datatype="html">
         <source>
-                        Veuillez zoomer pour localiser votre observation.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/&gt;"/>
-                        <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span&gt;"/>(zoom min:
-                            <x id="INTERPOLATION" equiv-text="{{ MainConfig.ZOOM_LEVEL_RELEVE }}"/>)<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span&gt;"/>
-                    </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/programs/observations/form/form.component.html</context>
-          <context context-type="linenumber">147</context>
-        </context-group>
-      </trans-unit>
+                        Veuillez zoomer pour localiser votre observation.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/>"/>
+                        <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span>"/>(zoom min:
+                            <x id="INTERPOLATION" equiv-text="{{ MainConfig.ZOOM_LEVEL_RELEVE }}"/>)<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span>"/>
+                    </source><target state="new">
+                        Bitte zoomen Sie, um Ihre Beobachtung zu lokalisieren.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/>"/>
+                        <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span>"/>(min. Zoom:
+                            <x id="INTERPOLATION" equiv-text="{{ MainConfig.ZOOM_LEVEL_RELEVE }}"/>)<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span>"/>
+                    </target>
+        
+      <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">147</context></context-group></trans-unit>
       <trans-unit id="zoomingInstruction" datatype="html">
-        <source>Veuillez zoomer pour localiser votre observation.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/programs/observations/form/form.component.html</context>
-          <context context-type="linenumber">160</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/programs/sites/siteform/siteform.component.html</context>
-          <context context-type="linenumber">33</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/programs/observations/validation/validation.component.html</context>
-          <context context-type="linenumber">115</context>
-        </context-group>
+        <source>Veuillez zoomer pour localiser votre observation.</source><target state="new">Bitte zoomen Sie, um Ihre Beobachtung zu lokalisieren.</target>
+        
+        
+        
         <note priority="1" from="description">
                         Zooming instruction</note>
-      </trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">160</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/programs/sites/siteform/siteform.component.html</context><context context-type="linenumber">33</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/programs/observations/validation/validation.component.html</context><context context-type="linenumber">115</context></context-group></trans-unit>
       <trans-unit id="clickOnMapInstruction" datatype="html">
         <source>Cliquez sur
                     la carte pour renseigner le lieu
                     précis de
-                    votre observation</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/programs/observations/form/form.component.html</context>
-          <context context-type="linenumber">165</context>
-        </context-group>
+                    votre observation</source><target state="new">Klicken Sie auf
+                    die Karte, um den genauen Ort
+                    Ihrer Beobachtung anzugeben</target>
+        
         <note priority="1" from="description">click on map instruction</note>
-      </trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">165</context></context-group></trans-unit>
       <trans-unit id="contactEmailInputLabel" datatype="html">
         <source>E-mail de contact
-                </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/programs/observations/form/form.component.html</context>
-          <context context-type="linenumber">180</context>
-        </context-group>
+                </source><target state="new">Kontakt-E-Mail
+                </target>
+        
         <note priority="1" from="description">Contact email input label</note>
-      </trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">180</context></context-group></trans-unit>
       <trans-unit id="contactEmailInputPlaceHolder" datatype="html">
-        <source>E-Mail</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/programs/observations/form/form.component.html</context>
-          <context context-type="linenumber">184</context>
-        </context-group>
+        <source>E-Mail</source><target state="new">E-Mail</target>
+        
         <note priority="1" from="description">
                         Contact email input
                         placeholder</note>
-      </trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">184</context></context-group></trans-unit>
       <trans-unit id="missingFieldsAlert" datatype="html">
         <source>
             Champs manquants
-        </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/programs/observations/form/form.component.html</context>
-          <context context-type="linenumber">191</context>
-        </context-group>
+        </source><target state="new">
+            Fehlende Felder
+        </target>
+        
         <note priority="1" from="description">Missing fields alert</note>
-      </trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">191</context></context-group></trans-unit>
       <trans-unit id="updateObs" datatype="html">
         <source>
-        MODIFIER L&apos;OBSERVATION
-    </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/programs/observations/modalflow/steps/committed/committed.component.html</context>
-          <context context-type="linenumber">6</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/programs/observations/obs.component.html</context>
-          <context context-type="linenumber">72</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/programs/observations/obs.component.html</context>
-          <context context-type="linenumber">72</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/programs/observations/obs.component.html</context>
-          <context context-type="linenumber">72</context>
-        </context-group>
+        MODIFIER L'OBSERVATION
+    </source><target state="new">
+        BEOBACHTUNG BEARBEITEN
+    </target>
+        
+        
+        
+        
         <note priority="1" from="description">Update obs</note>
-      </trans-unit>
-      <trans-unit id="informationHeading" datatype="html">
-        <source>Information</source>
+      <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/modalflow/steps/committed/committed.component.html</context><context context-type="linenumber">6</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/programs/observations/obs.component.html</context><context context-type="linenumber">72</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/programs/observations/obs.component.html</context><context context-type="linenumber">72</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/programs/observations/obs.component.html</context><context context-type="linenumber">72</context></context-group></trans-unit><trans-unit id="informationHeading" datatype="html">
+        <source>Information</source><target state="new">Information</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/observations/modalflow/steps/committed/committed.component.html</context>
           <context context-type="linenumber">20</context>
         </context-group>
         <note priority="1" from="description">Heading for information section</note>
       </trans-unit>
+      <trans-unit id="obsActionBtn" datatype="html">
+  <source>
+            <x id="ICU" equiv-text="{ obsValidatable, select, true {...} false {...}}"/>
+        </source>
+  <target state="new">
+    { obsValidatable, select,
+      true { { obsCorrection, select,
+                true {Beobachtung korrigieren}
+                false {Beobachtung validieren}
+              }
+            }
+      false {Beobachtung ungültig machen}
+    }
+  </target>
+<context-group purpose="location"><context context-type="sourcefile">app/programs/observations/validation/validation.component.html</context><context context-type="linenumber">154</context></context-group><note from="description" priority="1">Button for validating, correcting, or invalidating an observation</note></trans-unit><trans-unit id="a5cf87dd6048bc6d23f027b10d8a50f741000bc3" datatype="html">
+        <source>{VAR_SELECT_1, select, true {{VAR_SELECT, select, true {Corriger l'observation} false {Valider l'observation} }
+                    } false {Invalider l'observation} }</source><target state="new">{VAR_SELECT_1, select, true {{VAR_SELECT, select, true {Beobachtung korrigieren} false {Beobachtung validieren} }
+                    } false {Beobachtung ungültig machen} }</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/observations/validation/validation.component.html</context>
+          <context context-type="linenumber">155</context>
+        </context-group>
+      </trans-unit><trans-unit id="discoverINPN" datatype="html">
+        <source>Découvrir sur INPN</source><target state="new">Auf INPN entdecken</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/synthesis/species/species.component.html</context>
+          <context context-type="linenumber">20</context>
+        </context-group>
+        <note priority="1" from="description">Link to INPN</note>
+      </trans-unit>
+
       <trans-unit id="validObsBtn" datatype="html">
         <source>
-        Valider l&apos;observation
-    </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/programs/observations/modalflow/steps/committed/committed.component.html</context>
-          <context context-type="linenumber">32</context>
-        </context-group>
+        Valider l'observation
+    </source><target state="new">
+        Beobachtung validieren
+    </target>
+        
+        
         <note priority="1" from="description">Valid obs btn</note>
-      </trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/modalflow/steps/committed/committed.component.html</context><context context-type="linenumber">32</context></context-group></trans-unit>
       <trans-unit id="updateObsBtn" datatype="html">
         <source>
-        Modifier l&apos;observation
-    </source>
+        Modifier l'observation
+    </source><target state="new">
+        Beobachtung bearbeiten
+    </target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/observations/modalflow/steps/committed/committed.component.html</context>
           <context context-type="linenumber">37</context>
@@ -828,35 +774,15 @@
       <trans-unit id="cancel" datatype="html">
         <source>
         Annuler
-    </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/programs/observations/modalflow/steps/committed/committed.component.html</context>
-          <context context-type="linenumber">40</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
-          <context context-type="linenumber">193</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
-          <context context-type="linenumber">193</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context>
-          <context context-type="linenumber">242</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context>
-          <context context-type="linenumber">262</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/programs/observations/validation/validation.component.html</context>
-          <context context-type="linenumber">166</context>
-        </context-group>
+    </source><target state="new">
+        Abbrechen
+    </target>
+        
+        
         <note priority="1" from="description">Cancel</note>
-      </trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/modalflow/steps/committed/committed.component.html</context><context context-type="linenumber">40</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/programs/base/detail/detail.component.html</context><context context-type="linenumber">193</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/programs/base/detail/detail.component.html</context><context context-type="linenumber">193</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">242</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">262</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/programs/observations/validation/validation.component.html</context><context context-type="linenumber">166</context></context-group></trans-unit>
       <trans-unit id="congrats" datatype="html">
-        <source>Félicitations !</source>
+        <source>Félicitations !</source><target state="new">Herzlichen Glückwunsch!</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/observations/modalflow/steps/congrats/congrats.component.html</context>
           <context context-type="linenumber">16</context>
@@ -870,20 +796,16 @@
       <trans-unit id="congratsMessage" datatype="html">
         <source>
         Votre observation a bien été ajoutée !
-    </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/programs/observations/modalflow/steps/congrats/congrats.component.html</context>
-          <context context-type="linenumber">17</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/programs/sites/modalflow/steps/congrats/congrats.component.html</context>
-          <context context-type="linenumber">5</context>
-        </context-group>
+    </source><target state="new">
+        Ihre Beobachtung wurde erfolgreich hinzugefügt!
+    </target>
+        
         <note priority="1" from="description">Congrats message</note>
-      </trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/modalflow/steps/congrats/congrats.component.html</context><context context-type="linenumber">17</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/programs/sites/modalflow/steps/congrats/congrats.component.html</context><context context-type="linenumber">5</context></context-group></trans-unit>
       <trans-unit id="obsDateObserver" datatype="html">
-        <source>Observé par <x id="INTERPOLATION" equiv-text="{{ username || &apos;Anonyme&apos; }}"/> <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/&gt;"/>
-        le <x id="INTERPOLATION_1" equiv-text="{{ obs.date }}"/></source>
+        <source>Observé par <x id="INTERPOLATION" equiv-text="{{ username || 'Anonyme' }}"/> <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/>"/>
+        le <x id="INTERPOLATION_1" equiv-text="{{ obs.date }}"/></source><target state="new">Beobachtet von <x id="INTERPOLATION" equiv-text="{{ username || 'Anonyme' }}"/> <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/>"/>
+        am <x id="INTERPOLATION_1" equiv-text="{{ obs.date }}"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/observations/modalflow/steps/congrats/congrats.component.html</context>
           <context context-type="linenumber">21</context>
@@ -893,7 +815,9 @@
       <trans-unit id="newRewardMessage" datatype="html">
         <source>
             <x id="ICU" equiv-text="{ +rewards?.length, plural, =1 {...} other {...}}"/>
-        </source>
+        </source><target state="new">
+            <x id="ICU" equiv-text="{ +rewards?.length, plural, =1 {...} other {...}}"/>
+        </target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/observations/modalflow/steps/reward/reward.component.html</context>
           <context context-type="linenumber">7</context>
@@ -901,26 +825,28 @@
         <note priority="1" from="description">New reward message</note>
       </trans-unit>
       <trans-unit id="ab0413f2974d14060a3f1b621ef18bd194be83ad" datatype="html">
-        <source>{VAR_PLURAL, plural, =1 {Vous venez d&apos;obtenir
-            ce badge } other {Vous venez d&apos;obtenir ces badges } }</source>
+        <source>{VAR_PLURAL, plural, =1 {Vous venez d'obtenir
+            ce badge } other {Vous venez d'obtenir ces badges } }</source><target state="new">{VAR_PLURAL, plural, =1 {Sie haben gerade
+            dieses Abzeichen erhalten } other {Sie haben gerade diese Abzeichen erhalten } }</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/observations/modalflow/steps/reward/reward.component.html</context>
           <context context-type="linenumber">8</context>
         </context-group>
-      </trans-unit>
-      <trans-unit id="zoomWarning" datatype="html">
-        <source>Veuillez zoomer pour localiser votre observation.</source>
+      </trans-unit><trans-unit id="zoomWarning" datatype="html">
+        <source>Veuillez zoomer pour localiser votre observation.</source><target state="new">Bitte zoomen Sie, um Ihre Beobachtung zu lokalisieren.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/observations/map/map.component.html</context>
           <context context-type="linenumber">4</context>
         </context-group>
         <note priority="1" from="description">Warning message for zoom on observation map</note>
-      </trans-unit>
-      <trans-unit id="observationDetailsLink" datatype="html">
-        <source><x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;"/><x id="INTERPOLATION" equiv-text="{{ m.name }}"/> le <x id="INTERPOLATION_1" equiv-text="{{ m.date | date: &apos;longDate&apos; }}"/><x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> par @<x id="INTERPOLATION_2" equiv-text="{{
+      </trans-unit><trans-unit id="observationDetailsLink" datatype="html">
+        <source><x id="START_LINK" ctype="x-a" equiv-text="&lt;a>"/><x id="INTERPOLATION" equiv-text="{{ m.name }}"/> le <x id="INTERPOLATION_1" equiv-text="{{ m.date | date: 'longDate' }}"/><x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/> par @<x id="INTERPOLATION_2" equiv-text="{{
                     m.observer
                     }}"/>
-                </source>
+                </source><target state="new"><x id="START_LINK" ctype="x-a" equiv-text="&lt;a>"/><x id="INTERPOLATION" equiv-text="{{ m.name }}"/> am <x id="INTERPOLATION_1" equiv-text="{{ m.date | date: 'longDate' }}"/><x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/> von @<x id="INTERPOLATION_2" equiv-text="{{
+                    m.observer
+                    }}"/>
+                </target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/media-galery/media-galery.component.html</context>
           <context context-type="linenumber">7</context>
@@ -928,20 +854,24 @@
         <note priority="1" from="description">Link text for observation details</note>
       </trans-unit>
       <trans-unit id="NoMediasInfo" datatype="html">
-        <source>Aucune photo</source>
+        <source>Aucune photo</source><target state="new">Keine Fotos</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/media-galery/media-galery.component.html</context>
           <context context-type="linenumber">18</context>
         </context-group>
         <note priority="1" from="description">No medias</note>
-      </trans-unit>
-      <trans-unit id="clickedPhotoModalTitle" datatype="html">
+      </trans-unit><trans-unit id="clickedPhotoModalTitle" datatype="html">
         <source>
                     <x id="INTERPOLATION" equiv-text="{{ clickedPhoto.name }}"/> le
-                    <x id="INTERPOLATION_1" equiv-text="{{ clickedPhoto.date | date: &apos;longDate&apos; }}"/> par @<x id="INTERPOLATION_2" equiv-text="{{
+                    <x id="INTERPOLATION_1" equiv-text="{{ clickedPhoto.date | date: 'longDate' }}"/> par @<x id="INTERPOLATION_2" equiv-text="{{
                     clickedPhoto.observer
                     }}"/>
-                </source>
+                </source><target state="new">
+                    <x id="INTERPOLATION" equiv-text="{{ clickedPhoto.name }}"/> am
+                    <x id="INTERPOLATION_1" equiv-text="{{ clickedPhoto.date | date: 'longDate' }}"/> von @<x id="INTERPOLATION_2" equiv-text="{{
+                    clickedPhoto.observer
+                    }}"/>
+                </target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/media-galery/media-galery.component.html</context>
           <context context-type="linenumber">28</context>
@@ -951,7 +881,9 @@
       <trans-unit id="allSpeciesSelectOption" datatype="html">
         <source>
                         Toutes espèces
-                    </source>
+                    </source><target state="new">
+                        Alle Arten
+                    </target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/observations/list/list.component.html</context>
           <context context-type="linenumber">8</context>
@@ -961,7 +893,9 @@
       <trans-unit id="allMunicipalitiesSelectOption" datatype="html">
         <source>
                         Toutes communes
-                    </source>
+                    </source><target state="new">
+                        Alle Gemeinden
+                    </target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/observations/list/list.component.html</context>
           <context context-type="linenumber">22</context>
@@ -973,7 +907,9 @@
       <trans-unit id="allValidationStatusSelectOption" datatype="html">
         <source>
                         Tous statuts de validation
-                    </source>
+                    </source><target state="new">
+                        Alle Validierungsstatus
+                    </target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/observations/list/list.component.html</context>
           <context context-type="linenumber">33</context>
@@ -981,57 +917,53 @@
         <note priority="1" from="description">All validation status select option</note>
       </trans-unit>
       <trans-unit id="myObs" datatype="html">
-        <source><x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span&gt;"/>Mes
-                        <x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span&gt;"/>Observations<x id="START_TAG_SPAN_1" ctype="x-span" equiv-text="&lt;span&gt;"/> à valider <x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span&gt;"/> 
-                    </source>
+        <source><x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span>"/>Mes
+                        <x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span>"/>Observations<x id="START_TAG_SPAN_1" ctype="x-span" equiv-text="&lt;span>"/> à valider <x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span>"/> 
+                    </source><target state="new"><x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span>"/>Meine
+                        <x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span>"/>OBSERVATIONEN<x id="START_TAG_SPAN_1" ctype="x-span" equiv-text="&lt;span>"/> zu validieren <x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span>"/> 
+                    </target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/observations/list/list.component.html</context>
           <context context-type="linenumber">43</context>
         </context-group>
         <note priority="1" from="description">My obs</note>
-      </trans-unit>
-      <trans-unit id="observationWithPhotoTooltip" datatype="html">
-        <source>Observation avec photo</source>
+      </trans-unit><trans-unit id="observationWithPhotoTooltip" datatype="html">
+        <source>Observation avec photo</source><target state="new">Beobachtung mit Foto</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/observations/list/list.component.html</context>
           <context context-type="linenumber">70</context>
         </context-group>
         <note priority="1" from="description">Tooltip for observation with photo</note>
-      </trans-unit>
-      <trans-unit id="nonValidatedObservationTooltip" datatype="html">
-        <source>Observation non validée<x id="INTERPOLATION" equiv-text="{{o.properties.observer?.username == username ? &apos; - Validation par un tiers requise&apos; : &apos;&apos;}}"/></source>
+      </trans-unit><trans-unit id="nonValidatedObservationTooltip" datatype="html">
+        <source>Observation non validée<x id="INTERPOLATION" equiv-text="{{o.properties.observer?.username == username ? ' - Validation par un tiers requise' : ''}}"/></source><target state="new">Beobachtung nicht validiert<x id="INTERPOLATION" equiv-text="{{o.properties.observer?.username == username ? ' - Validierung durch Dritte erforderlich' : ''}}"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/observations/list/list.component.html</context>
           <context context-type="linenumber">104</context>
         </context-group>
         <note priority="1" from="description">Tooltip for non-validated observation</note>
-      </trans-unit>
-      <trans-unit id="invalidObservationTooltip" datatype="html">
-        <source>Observation invalide<x id="INTERPOLATION" equiv-text="{{o.properties.observer?.username == username ? &apos; - Validation par un tiers requise&apos; : &apos;&apos;}}"/></source>
+      </trans-unit><trans-unit id="invalidObservationTooltip" datatype="html">
+        <source>Observation invalide<x id="INTERPOLATION" equiv-text="{{o.properties.observer?.username == username ? ' - Validation par un tiers requise' : ''}}"/></source><target state="new">Ungültige Beobachtung<x id="INTERPOLATION" equiv-text="{{o.properties.observer?.username == username ? ' - Validierung durch Dritte erforderlich' : ''}}"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/observations/list/list.component.html</context>
           <context context-type="linenumber">109</context>
         </context-group>
         <note priority="1" from="description">Tooltip for invalid observation</note>
-      </trans-unit>
-      <trans-unit id="nonValidatableObservationTooltip" datatype="html">
-        <source>Observation non validable<x id="INTERPOLATION" equiv-text="{{o.properties.observer?.username == username ? &apos; - Validation par un tiers requise&apos; : &apos;&apos;}}"/></source>
+      </trans-unit><trans-unit id="nonValidatableObservationTooltip" datatype="html">
+        <source>Observation non validable<x id="INTERPOLATION" equiv-text="{{o.properties.observer?.username == username ? ' - Validation par un tiers requise' : ''}}"/></source><target state="new">Beobachtung nicht validierbar<x id="INTERPOLATION" equiv-text="{{o.properties.observer?.username == username ? ' - Validierung durch Dritte erforderlich' : ''}}"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/observations/list/list.component.html</context>
           <context context-type="linenumber">114</context>
         </context-group>
         <note priority="1" from="description">Tooltip for non-validatable observation</note>
-      </trans-unit>
-      <trans-unit id="validatedObservationTooltip" datatype="html">
-        <source>Observation approuvée</source>
+      </trans-unit><trans-unit id="validatedObservationTooltip" datatype="html">
+        <source>Observation approuvée</source><target state="new">Beobachtung genehmigt</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/observations/list/list.component.html</context>
           <context context-type="linenumber">119</context>
         </context-group>
         <note priority="1" from="description">Tooltip for validated observation</note>
-      </trans-unit>
-      <trans-unit id="editButtonTooltip" datatype="html">
-        <source>Editer</source>
+      </trans-unit><trans-unit id="editButtonTooltip" datatype="html">
+        <source>Editer</source><target state="new">Bearbeiten</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/observations/list/list.component.html</context>
           <context context-type="linenumber">146</context>
@@ -1041,9 +973,8 @@
           <context context-type="linenumber">24</context>
         </context-group>
         <note priority="1" from="description">Tooltip for edit button</note>
-      </trans-unit>
-      <trans-unit id="deleteButtonTooltip" datatype="html">
-        <source>Supprimer</source>
+      </trans-unit><trans-unit id="deleteButtonTooltip" datatype="html">
+        <source>Supprimer</source><target state="new">Löschen</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/observations/list/list.component.html</context>
           <context context-type="linenumber">150</context>
@@ -1053,33 +984,29 @@
           <context context-type="linenumber">31</context>
         </context-group>
         <note priority="1" from="description">Tooltip for delete button</note>
-      </trans-unit>
-      <trans-unit id="datePrefix" datatype="html">
-        <source>le</source>
+      </trans-unit><trans-unit id="datePrefix" datatype="html">
+        <source>le</source><target state="new">am</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/observations/list/list.component.html</context>
           <context context-type="linenumber">157</context>
         </context-group>
         <note priority="1" from="description">Date prefix</note>
-      </trans-unit>
-      <trans-unit id="locationPrefix" datatype="html">
-        <source>à</source>
+      </trans-unit><trans-unit id="locationPrefix" datatype="html">
+        <source>à</source><target state="new">um</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/observations/list/list.component.html</context>
           <context context-type="linenumber">160</context>
         </context-group>
         <note priority="1" from="description">Location prefix</note>
-      </trans-unit>
-      <trans-unit id="viewObservationDetailsTooltip" datatype="html">
-        <source>Voir les détails de cette observation</source>
+      </trans-unit><trans-unit id="viewObservationDetailsTooltip" datatype="html">
+        <source>Voir les détails de cette observation</source><target state="new">Details dieser Beobachtung anzeigen</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/observations/list/list.component.html</context>
           <context context-type="linenumber">171</context>
         </context-group>
         <note priority="1" from="description">Tooltip for viewing observation details</note>
-      </trans-unit>
-      <trans-unit id="addButtonText" datatype="html">
-        <source>Ajouter</source>
+      </trans-unit><trans-unit id="addButtonText" datatype="html">
+        <source>Ajouter</source><target state="new">Hinzufügen</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/observations/obs.component.html</context>
           <context context-type="linenumber">47</context>
@@ -1109,9 +1036,8 @@
           <context context-type="linenumber">82</context>
         </context-group>
         <note priority="1" from="description">Add button text</note>
-      </trans-unit>
-      <trans-unit id="addObservationTooltip" datatype="html">
-        <source>Ajouter une observation</source>
+      </trans-unit><trans-unit id="addObservationTooltip" datatype="html">
+        <source>Ajouter une observation</source><target state="new">Eine Beobachtung hinzufügen</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/observations/obs.component.html</context>
           <context context-type="linenumber">45</context>
@@ -1125,33 +1051,29 @@
           <context context-type="linenumber">45</context>
         </context-group>
         <note priority="1" from="description">Ajouter une observation</note>
-      </trans-unit>
-      <trans-unit id="informations" datatype="html">
-        <source>Informations</source>
+      </trans-unit><trans-unit id="informations" datatype="html">
+        <source>Informations</source><target state="new">Informations</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/sites/siteform/siteform.component.html</context>
           <context context-type="linenumber">5</context>
         </context-group>
         <note priority="1" from="description">Informations</note>
-      </trans-unit>
-      <trans-unit id="siteTypeLabel" datatype="html">
-        <source>Type de site</source>
+      </trans-unit><trans-unit id="siteTypeLabel" datatype="html">
+        <source>Type de site</source><target state="new">Standorttyp</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/sites/siteform/siteform.component.html</context>
           <context context-type="linenumber">8</context>
         </context-group>
         <note priority="1" from="description">Libellé pour le champ Type de site</note>
-      </trans-unit>
-      <trans-unit id="siteNameLabel" datatype="html">
-        <source>Nom du site</source>
+      </trans-unit><trans-unit id="siteNameLabel" datatype="html">
+        <source>Nom du site</source><target state="new">Name des Standorts</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/sites/siteform/siteform.component.html</context>
           <context context-type="linenumber">25</context>
         </context-group>
         <note priority="1" from="description">Libellé pour le champ Nom du site</note>
-      </trans-unit>
-      <trans-unit id="locationSiteQuestion" datatype="html">
-        <source>Où est-il situé ?</source>
+      </trans-unit><trans-unit id="locationSiteQuestion" datatype="html">
+        <source>Où est-il situé ?</source><target state="new">Wo befindet es sich?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/sites/siteform/siteform.component.html</context>
           <context context-type="linenumber">30</context>
@@ -1159,154 +1081,154 @@
         <note priority="1" from="description">Question localisation site</note>
       </trans-unit>
       <trans-unit id="zoomingWarning" datatype="html">
-        <source>Veuillez zoomer pour localiser votre observation.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/programs/sites/siteform/siteform.component.html</context>
-          <context context-type="linenumber">50</context>
-        </context-group>
+        <source>Veuillez zoomer pour localiser votre observation.</source><target state="new">Bitte zoomen Sie, um Ihre Beobachtung zu lokalisieren.</target>
+        
         <note priority="1" from="description">Zooming warning</note>
-      </trans-unit>
-      <trans-unit id="addSiteTitle" datatype="html">
-        <source>AJOUTER UN SITE</source>
+      <context-group purpose="location"><context context-type="sourcefile">app/programs/sites/siteform/siteform.component.html</context><context context-type="linenumber">50</context></context-group></trans-unit><trans-unit id="addSiteTitle" datatype="html">
+        <source>AJOUTER UN SITE</source><target state="new">EINE STANDORT HINZUFÜGEN</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/sites/modalflow/steps/site/site_step.component.html</context>
           <context context-type="linenumber">3</context>
         </context-group>
         <note priority="1" from="description">Title for add site</note>
-      </trans-unit>
-      <trans-unit id="validSiteButton" datatype="html">
+      </trans-unit><trans-unit id="validSiteButton" datatype="html">
         <source>
         Valider le site
-    </source>
+    </source><target state="new">
+        Standort bestätigen
+    </target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/sites/modalflow/steps/site/site_step.component.html</context>
           <context context-type="linenumber">29</context>
         </context-group>
         <note priority="1" from="description">button valid site</note>
-      </trans-unit>
-      <trans-unit id="stepTitle" datatype="html">
+      </trans-unit><trans-unit id="stepTitle" datatype="html">
         <source>
             Etape <x id="INTERPOLATION" equiv-text="{{ currentStep }}"/>/<x id="INTERPOLATION_1" equiv-text="{{ totalSteps() }}"/> :
             <x id="INTERPOLATION_2" equiv-text="{{ jsonSchema.steps[currentStep - 1].title }}"/>
-        </source>
+        </source><target state="new">
+            Schritt <x id="INTERPOLATION" equiv-text="{{ currentStep }}"/>/<x id="INTERPOLATION_1" equiv-text="{{ totalSteps() }}"/> :
+            <x id="INTERPOLATION_2" equiv-text="{{ jsonSchema.steps[currentStep - 1].title }}"/>
+        </target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/sites/form/form.component.html</context>
           <context context-type="linenumber">3</context>
         </context-group>
         <note priority="1" from="description">Step Title</note>
-      </trans-unit>
-      <trans-unit id="visitDate" datatype="html">
-        <source>Date de la visite</source>
+      </trans-unit><trans-unit id="visitDate" datatype="html">
+        <source>Date de la visite</source><target state="new">Besuchsdatum</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/sites/form/form.component.html</context>
           <context context-type="linenumber">13</context>
         </context-group>
         <note priority="1" from="description">Visit Date</note>
-      </trans-unit>
-      <trans-unit id="dateRequired" datatype="html">
+      </trans-unit><trans-unit id="dateRequired" datatype="html">
         <source>
                             La date est obligatoire
-                        </source>
+                        </source><target state="new">
+                            Das Datum ist erforderlich
+                        </target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/sites/form/form.component.html</context>
           <context context-type="linenumber">17</context>
         </context-group>
         <note priority="1" from="description">Date Required</note>
-      </trans-unit>
-      <trans-unit id="futureDateError" datatype="html">
+      </trans-unit><trans-unit id="futureDateError" datatype="html">
         <source>
                             La date doit être antérieure à la date du jour
-                        </source>
+                        </source><target state="new">
+                            Das Datum muss vor dem heutigen Datum liegen
+                        </target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/sites/form/form.component.html</context>
           <context context-type="linenumber">24</context>
         </context-group>
-        <note priority="1" from="description">Message d&apos;erreur pour une date future</note>
-      </trans-unit>
-      <trans-unit id="invalidDateError" datatype="html">
+        <note priority="1" from="description">Message d'erreur pour une date future</note>
+      </trans-unit><trans-unit id="invalidDateError" datatype="html">
         <source>
                             Date invalide
-                        </source>
+                        </source><target state="new">
+                            Ungültiges Datum
+                        </target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/sites/form/form.component.html</context>
           <context context-type="linenumber">27</context>
         </context-group>
-        <note priority="1" from="description">Message d&apos;erreur pour une date invalide</note>
-      </trans-unit>
-      <trans-unit id="addSiteVisitReportTitle" datatype="html">
-        <source>AJOUTER UN RAPPORT DE VISITE</source>
+        <note priority="1" from="description">Message d'erreur pour une date invalide</note>
+      </trans-unit><trans-unit id="addSiteVisitReportTitle" datatype="html">
+        <source>AJOUTER UN RAPPORT DE VISITE</source><target state="new">EINEN BESUCHSBERICHT HINZUFÜGEN</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/sites/modalflow/steps/visit/visit_step.component.html</context>
           <context context-type="linenumber">3</context>
         </context-group>
         <note priority="1" from="description">Modal title for adding a site visit report</note>
-      </trans-unit>
-      <trans-unit id="previousStep" datatype="html">
+      </trans-unit><trans-unit id="previousStep" datatype="html">
         <source>
         Etape précédente
-    </source>
+    </source><target state="new">
+        Vorheriger Schritt
+    </target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/sites/modalflow/steps/visit/visit_step.component.html</context>
           <context context-type="linenumber">28</context>
         </context-group>
         <note priority="1" from="description">Previous Step</note>
-      </trans-unit>
-      <trans-unit id="nextStep" datatype="html">
+      </trans-unit><trans-unit id="nextStep" datatype="html">
         <source>
         Etape suivante
-    </source>
+    </source><target state="new">
+        Nächster Schritt
+    </target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/sites/modalflow/steps/visit/visit_step.component.html</context>
           <context context-type="linenumber">37</context>
         </context-group>
         <note priority="1" from="description">Next Step</note>
-      </trans-unit>
-      <trans-unit id="validVisitButton" datatype="html">
+      </trans-unit><trans-unit id="validVisitButton" datatype="html">
         <source>
         Valider la visite
-    </source>
+    </source><target state="new">
+        Besuch bestätigen
+    </target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/sites/modalflow/steps/visit/visit_step.component.html</context>
           <context context-type="linenumber">47</context>
         </context-group>
         <note priority="1" from="description">button valid visit</note>
-      </trans-unit>
-      <trans-unit id="congratsTitle" datatype="html">
-        <source>Félicitations !</source>
+      </trans-unit><trans-unit id="congratsTitle" datatype="html">
+        <source>Félicitations !</source><target state="new">Herzlichen Glückwunsch !</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/sites/modalflow/steps/congrats/congrats.component.html</context>
           <context context-type="linenumber">4</context>
         </context-group>
         <note priority="1" from="description">Félicitations</note>
-      </trans-unit>
-      <trans-unit id="mySitesTitle" datatype="html">
-        <source>Mes Sites </source>
+      </trans-unit><trans-unit id="mySitesTitle" datatype="html">
+        <source>Mes Sites </source><target state="new">Meine Standorte</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/sites/list/list.component.html</context>
           <context context-type="linenumber">6</context>
         </context-group>
         <note priority="1" from="description">Titre pour Mes Sites</note>
-      </trans-unit>
-      <trans-unit id="addedMessage" datatype="html">
+      </trans-unit><trans-unit id="addedMessage" datatype="html">
         <source>
-                            <x id="START_TAG_NG-CONTAINER" ctype="x-ng-container" equiv-text="&lt;ng-container&gt;"/><x id="INTERPOLATION" equiv-text="{{ o.properties.site_type.type | titlecase }}"/><x id="CLOSE_TAG_NG-CONTAINER" ctype="x-ng-container" equiv-text="&lt;/ng-container&gt;"/> ajouté(e) par <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span&gt;"/><x id="INTERPOLATION_1" equiv-text="{{ o.properties.obs_txt }}"/><x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span&gt;"/>
-                        </source>
+                            <x id="START_TAG_NG-CONTAINER" ctype="x-ng-container" equiv-text="&lt;ng-container>"/><x id="INTERPOLATION" equiv-text="{{ o.properties.site_type.type | titlecase }}"/><x id="CLOSE_TAG_NG-CONTAINER" ctype="x-ng-container" equiv-text="&lt;/ng-container>"/> ajouté(e) par <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span>"/><x id="INTERPOLATION_1" equiv-text="{{ o.properties.obs_txt }}"/><x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span>"/>
+                        </source><target state="new">
+                            <x id="START_TAG_NG-CONTAINER" ctype="x-ng-container" equiv-text="&lt;ng-container>"/><x id="INTERPOLATION" equiv-text="{{ o.properties.site_type.type | titlecase }}"/><x id="CLOSE_TAG_NG-CONTAINER" ctype="x-ng-container" equiv-text="&lt;/ng-container>"/> hinzugefügt von <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span>"/><x id="INTERPOLATION_1" equiv-text="{{ o.properties.obs_txt }}"/><x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span>"/>
+                        </target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/sites/list/list.component.html</context>
           <context context-type="linenumber">41</context>
         </context-group>
-        <note priority="1" from="description">Message d&apos;ajout</note>
-      </trans-unit>
-      <trans-unit id="dateDeterminer" datatype="html">
-        <source>le</source>
+        <note priority="1" from="description">Message d'ajout</note>
+      </trans-unit><trans-unit id="dateDeterminer" datatype="html">
+        <source>le</source><target state="new">am</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/sites/list/list.component.html</context>
           <context context-type="linenumber">46</context>
         </context-group>
         <note priority="1" from="description">Déterminant pour une date</note>
-      </trans-unit>
-      <trans-unit id="addSiteButton" datatype="html">
-        <source>Ajouter</source>
+      </trans-unit><trans-unit id="addSiteButton" datatype="html">
+        <source>Ajouter</source><target state="new">Hinzufügen</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/sites/sites.component.html</context>
           <context context-type="linenumber">45</context>
@@ -1316,9 +1238,8 @@
           <context context-type="linenumber">45</context>
         </context-group>
         <note priority="1" from="description">Add site button text</note>
-      </trans-unit>
-      <trans-unit id="addSiteTooltip" datatype="html">
-        <source>Ajouter un site</source>
+      </trans-unit><trans-unit id="addSiteTooltip" datatype="html">
+        <source>Ajouter un site</source><target state="new">Einen Standort hinzufügen</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/sites/sites.component.html</context>
           <context context-type="linenumber">44</context>
@@ -1328,11 +1249,12 @@
           <context context-type="linenumber">44</context>
         </context-group>
         <note priority="1" from="description">Tooltip for adding a site</note>
-      </trans-unit>
-      <trans-unit id="backToProgramLink" datatype="html">
+      </trans-unit><trans-unit id="backToProgramLink" datatype="html">
         <source>
-            <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i&gt;"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i&gt;"/>
-            Retour au programme</source>
+            <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i>"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i>"/>
+            Retour au programme</source><target state="new">
+            <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i>"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i>"/>
+            Zurück zum Programm</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
           <context context-type="linenumber">3</context>
@@ -1342,14 +1264,18 @@
           <context context-type="linenumber">3</context>
         </context-group>
         <note priority="1" from="description">Link to go back to the program</note>
-      </trans-unit>
-      <trans-unit id="addedDateObserverText" datatype="html">
+      </trans-unit><trans-unit id="addedDateObserverText" datatype="html">
         <source>Ajoutée le
-                    <x id="INTERPOLATION" equiv-text="{{ (module === &apos;sites&apos; ? site?.properties.timestamp_create.substring(0, 10) :
+                    <x id="INTERPOLATION" equiv-text="{{ (module === 'sites' ? site?.properties.timestamp_create.substring(0, 10) :
                     obs?.properties.timestamp_create.substring(0, 10))
-                    | date: &apos;longDate&apos;
+                    | date: 'longDate'
                     }}"/>
-                    par <x id="INTERPOLATION_1" equiv-text="{{ module === &apos;sites&apos; ? site?.properties.obs_txt: obs?.properties.obs_txt }}"/></source>
+                    par <x id="INTERPOLATION_1" equiv-text="{{ module === 'sites' ? site?.properties.obs_txt: obs?.properties.obs_txt }}"/></source><target state="new">Hinzugefügt am
+                    <x id="INTERPOLATION" equiv-text="{{ (module === 'sites' ? site?.properties.timestamp_create.substring(0, 10) :
+                    obs?.properties.timestamp_create.substring(0, 10))
+                    | date: 'longDate'
+                    }}"/>
+                    von <x id="INTERPOLATION_1" equiv-text="{{ module === 'sites' ? site?.properties.obs_txt: obs?.properties.obs_txt }}"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
           <context context-type="linenumber">19</context>
@@ -1359,15 +1285,20 @@
           <context context-type="linenumber">19</context>
         </context-group>
         <note priority="1" from="description">Text for added date and observer</note>
-      </trans-unit>
-      <trans-unit id="singleSiteVisitText" datatype="html">
+      </trans-unit><trans-unit id="singleSiteVisitText" datatype="html">
         <source>
                             Visite du
                             <x id="INTERPOLATION" equiv-text="{{
                             site?.properties.visits[0].date
-                            | date: &apos;longDate&apos;
+                            | date: 'longDate'
                             }}"/>
-                        </source>
+                        </source><target state="new">
+                            Besuch vom
+                            <x id="INTERPOLATION" equiv-text="{{
+                            site?.properties.visits[0].date
+                            | date: 'longDate'
+                            }}"/>
+                        </target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
           <context context-type="linenumber">40</context>
@@ -1377,9 +1308,8 @@
           <context context-type="linenumber">40</context>
         </context-group>
         <note priority="1" from="description">Text for a single site visit date</note>
-      </trans-unit>
-      <trans-unit id="noVisitsMessage" datatype="html">
-        <source>Aucune visite enregistrée :(</source>
+      </trans-unit><trans-unit id="noVisitsMessage" datatype="html">
+        <source>Aucune visite enregistrée :(</source><target state="new">Kein Besuch registriert :(</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
           <context context-type="linenumber">54</context>
@@ -1389,10 +1319,9 @@
           <context context-type="linenumber">54</context>
         </context-group>
         <note priority="1" from="description">No visits recorded message</note>
-      </trans-unit>
-      <trans-unit id="addSiteVisitReportButton" datatype="html">
+      </trans-unit><trans-unit id="addSiteVisitReportButton" datatype="html">
         <source>Ajouter un rapport
-                    de visite</source>
+                    de visite</source><target state="new">Einen Besuchsbericht hinzufügen</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
           <context context-type="linenumber">58</context>
@@ -1402,9 +1331,8 @@
           <context context-type="linenumber">58</context>
         </context-group>
         <note priority="1" from="description">Button to add a site visit report</note>
-      </trans-unit>
-      <trans-unit id="observationCardTitle" datatype="html">
-        <source>Observation #<x id="INTERPOLATION" equiv-text="{{ obs_id }}"/></source>
+      </trans-unit><trans-unit id="observationCardTitle" datatype="html">
+        <source>Observation #<x id="INTERPOLATION" equiv-text="{{ obs_id }}"/></source><target state="new">Beobachtung #<x id="INTERPOLATION" equiv-text="{{ obs_id }}"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
           <context context-type="linenumber">65</context>
@@ -1414,9 +1342,8 @@
           <context context-type="linenumber">65</context>
         </context-group>
         <note priority="1" from="description">Observation card title with ID</note>
-      </trans-unit>
-      <trans-unit id="observerLabel" datatype="html">
-        <source>Observateur :</source>
+      </trans-unit><trans-unit id="observerLabel" datatype="html">
+        <source>Observateur :</source><target state="new">Beobachter :</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
           <context context-type="linenumber">67</context>
@@ -1426,9 +1353,8 @@
           <context context-type="linenumber">67</context>
         </context-group>
         <note priority="1" from="description">Observer label</note>
-      </trans-unit>
-      <trans-unit id="dateLabel" datatype="html">
-        <source>Date :</source>
+      </trans-unit><trans-unit id="dateLabel" datatype="html">
+        <source>Date :</source><target state="new">Datum :</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
           <context context-type="linenumber">68</context>
@@ -1438,9 +1364,8 @@
           <context context-type="linenumber">68</context>
         </context-group>
         <note priority="1" from="description">Date label</note>
-      </trans-unit>
-      <trans-unit id="municipalityLabel" datatype="html">
-        <source>Commune :</source>
+      </trans-unit><trans-unit id="municipalityLabel" datatype="html">
+        <source>Commune :</source><target state="new">Gemeinde :</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
           <context context-type="linenumber">70</context>
@@ -1450,9 +1375,8 @@
           <context context-type="linenumber">70</context>
         </context-group>
         <note priority="1" from="description">Municipality label</note>
-      </trans-unit>
-      <trans-unit id="countLabel" datatype="html">
-        <source>Nombre :</source>
+      </trans-unit><trans-unit id="countLabel" datatype="html">
+        <source>Nombre :</source><target state="new">Anzahl :</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
           <context context-type="linenumber">72</context>
@@ -1462,9 +1386,8 @@
           <context context-type="linenumber">72</context>
         </context-group>
         <note priority="1" from="description">Count label</note>
-      </trans-unit>
-      <trans-unit id="photosSectionTitle" datatype="html">
-        <source>Photos</source>
+      </trans-unit><trans-unit id="photosSectionTitle" datatype="html">
+        <source>Photos</source><target state="new">Fotos</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
           <context context-type="linenumber">84</context>
@@ -1474,9 +1397,8 @@
           <context context-type="linenumber">84</context>
         </context-group>
         <note priority="1" from="description">Section title for photos</note>
-      </trans-unit>
-      <trans-unit id="photoDateAuthorLabel" datatype="html">
-        <source>Le <x id="INTERPOLATION" equiv-text="{{ photo.date | date: &apos;longDate&apos; }}"/> par <x id="INTERPOLATION_1" equiv-text="{{ photo.author }}"/></source>
+      </trans-unit><trans-unit id="photoDateAuthorLabel" datatype="html">
+        <source>Le <x id="INTERPOLATION" equiv-text="{{ photo.date | date: 'longDate' }}"/> par <x id="INTERPOLATION_1" equiv-text="{{ photo.author }}"/></source><target state="new">Am <x id="INTERPOLATION" equiv-text="{{ photo.date | date: 'longDate' }}"/> von <x id="INTERPOLATION_1" equiv-text="{{ photo.author }}"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
           <context context-type="linenumber">93</context>
@@ -1486,9 +1408,8 @@
           <context context-type="linenumber">93</context>
         </context-group>
         <note priority="1" from="description">Photo date and author label</note>
-      </trans-unit>
-      <trans-unit id="descriptionSectionTitle" datatype="html">
-        <source>Description</source>
+      </trans-unit><trans-unit id="descriptionSectionTitle" datatype="html">
+        <source>Description</source><target state="new">Beschreibung</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
           <context context-type="linenumber">101</context>
@@ -1506,15 +1427,20 @@
           <context context-type="linenumber">138</context>
         </context-group>
         <note priority="1" from="description">Section title for description</note>
-      </trans-unit>
-      <trans-unit id="siteVisitDateAuthor" datatype="html">
+      </trans-unit><trans-unit id="siteVisitDateAuthor" datatype="html">
         <source>
-                <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i&gt;"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i&gt;"/>
-                <x id="INTERPOLATION" equiv-text="{{ a.date | date: &apos;longDate&apos; }}"/> par <x id="INTERPOLATION_1" equiv-text="{{ a.author }}"/>
-                <x id="START_ITALIC_TEXT_1" ctype="x-i" equiv-text="&lt;i&gt;"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i&gt;"/>
+                <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i>"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i>"/>
+                <x id="INTERPOLATION" equiv-text="{{ a.date | date: 'longDate' }}"/> par <x id="INTERPOLATION_1" equiv-text="{{ a.author }}"/>
+                <x id="START_ITALIC_TEXT_1" ctype="x-i" equiv-text="&lt;i>"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i>"/>
                  
-                <x id="START_ITALIC_TEXT_2" ctype="x-i" equiv-text="&lt;i&gt;"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i&gt;"/>
-            </source>
+                <x id="START_ITALIC_TEXT_2" ctype="x-i" equiv-text="&lt;i>"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i>"/>
+            </source><target state="new">
+                <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i>"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i>"/>
+                <x id="INTERPOLATION" equiv-text="{{ a.date | date: 'longDate' }}"/> von <x id="INTERPOLATION_1" equiv-text="{{ a.author }}"/>
+                <x id="START_ITALIC_TEXT_1" ctype="x-i" equiv-text="&lt;i>"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i>"/>
+                 
+                <x id="START_ITALIC_TEXT_2" ctype="x-i" equiv-text="&lt;i>"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i>"/>
+            </target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
           <context context-type="linenumber">106</context>
@@ -1524,9 +1450,8 @@
           <context context-type="linenumber">106</context>
         </context-group>
         <note priority="1" from="description">Date and author for site visit</note>
-      </trans-unit>
-      <trans-unit id="editSiteVisitTooltip" datatype="html">
-        <source>Editer</source>
+      </trans-unit><trans-unit id="editSiteVisitTooltip" datatype="html">
+        <source>Editer</source><target state="new">Bearbeiten</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
           <context context-type="linenumber">109</context>
@@ -1536,9 +1461,8 @@
           <context context-type="linenumber">109</context>
         </context-group>
         <note priority="1" from="description">Tooltip for edit site visit</note>
-      </trans-unit>
-      <trans-unit id="deleteSiteVisitTooltip" datatype="html">
-        <source>Supprimer</source>
+      </trans-unit><trans-unit id="deleteSiteVisitTooltip" datatype="html">
+        <source>Supprimer</source><target state="new">Löschen</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
           <context context-type="linenumber">113</context>
@@ -1548,9 +1472,8 @@
           <context context-type="linenumber">113</context>
         </context-group>
         <note priority="1" from="description">Tooltip for delete site visit</note>
-      </trans-unit>
-      <trans-unit id="noDataMessage" datatype="html">
-        <source>Aucune donnée</source>
+      </trans-unit><trans-unit id="noDataMessage" datatype="html">
+        <source>Aucune donnée</source><target state="new">Keine Daten</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
           <context context-type="linenumber">128</context>
@@ -1560,14 +1483,17 @@
           <context context-type="linenumber">128</context>
         </context-group>
         <note priority="1" from="description">No data available message</note>
-      </trans-unit>
-      <trans-unit id="deleteSiteVisitConfirmation" datatype="html">
+      </trans-unit><trans-unit id="deleteSiteVisitConfirmation" datatype="html">
         <source>
         Êtes-vous sûr de vouloir supprimer cette visite et toutes les informations
         qui y sont rattachées ?
-        <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/&gt;"/>
+        <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/>"/>
         La suppression sera définitive
-    </source>
+    </source><target state="new">
+        Sind Sie sicher, dass Sie diese Website und alle damit verbundenen Informationen?
+        <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/>"/>
+        Die Löschung ist endgültig
+    </target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
           <context context-type="linenumber">185</context>
@@ -1577,11 +1503,12 @@
           <context context-type="linenumber">185</context>
         </context-group>
         <note priority="1" from="description">Confirmation message for deleting a site visit</note>
-      </trans-unit>
-      <trans-unit id="yes" datatype="html">
+      </trans-unit><trans-unit id="yes" datatype="html">
         <source>
             OUI
-        </source>
+        </source><target state="new">
+            JA
+        </target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
           <context context-type="linenumber">197</context>
@@ -1601,7 +1528,7 @@
         <note priority="1" from="description">Yes</note>
       </trans-unit>
       <trans-unit id="scrollForMore" datatype="html">
-        <source>Scrollez pour en voir plus !</source>
+        <source>Scrollez pour en voir plus !</source><target state="new">Scrollen Sie, um mehr zu sehen!</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/home/home.component.html</context>
           <context context-type="linenumber">6</context>
@@ -1609,7 +1536,7 @@
         <note priority="1" from="description">Scroll down to see more !</note>
       </trans-unit>
       <trans-unit id="observations" datatype="html">
-        <source>Observations</source>
+        <source>Observations</source><target state="new">Observationen</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/home/home.component.html</context>
           <context context-type="linenumber">18</context>
@@ -1617,79 +1544,57 @@
         <note priority="1" from="description">Observations</note>
       </trans-unit>
       <trans-unit id="species" datatype="html">
-        <source>Espèces</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/home/home.component.html</context>
-          <context context-type="linenumber">27</context>
-        </context-group>
+        <source>Espèces</source><target state="new">Arten</target>
+        
         <note priority="1" from="description">species</note>
-      </trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/home/home.component.html</context><context context-type="linenumber">27</context></context-group></trans-unit>
       <trans-unit id="observers" datatype="html">
-        <source>Observateurs</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/home/home.component.html</context>
-          <context context-type="linenumber">36</context>
-        </context-group>
+        <source>Observateurs</source><target state="new">Beobachter</target>
+        
         <note priority="1" from="description">Observers</note>
-      </trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/home/home.component.html</context><context context-type="linenumber">36</context></context-group></trans-unit>
       <trans-unit id="momenPrograms" datatype="html">
-        <source>Les programmes du moment</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/home/home.component.html</context>
-          <context context-type="linenumber">98</context>
-        </context-group>
+        <source>Les programmes du moment</source><target state="new">Die Programme des Augenblicks</target>
+        
         <note priority="1" from="description">Programs of the moment</note>
-      </trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/home/home.component.html</context><context context-type="linenumber">98</context></context-group></trans-unit>
       <trans-unit id="ngbCarouselPrev" datatype="html">
-        <source>Précédent</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/home/home.component.html</context>
-          <context context-type="linenumber">123</context>
-        </context-group>
+        <source>Précédent</source><target state="new">Zurück</target>
+        
         <note priority="1" from="description">Carousel previous</note>
-      </trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/home/home.component.html</context><context context-type="linenumber">123</context></context-group></trans-unit>
       <trans-unit id="ngbCarouselNext" datatype="html">
-        <source>Prochain</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/home/home.component.html</context>
-          <context context-type="linenumber">127</context>
-        </context-group>
+        <source>Prochain</source><target state="new">Weiter</target>
+        
         <note priority="1" from="description">Carousel next</note>
-      </trans-unit>
-      <trans-unit id="pageNotFoundTitle" datatype="html">
-        <source>Page non trouvé</source>
+      <context-group purpose="location"><context context-type="sourcefile">app/home/home.component.html</context><context context-type="linenumber">127</context></context-group></trans-unit><trans-unit id="pageNotFoundTitle" datatype="html">
+        <source>Page non trouvé</source><target state="new">Seite nicht gefunden</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/page-not-found/page-not-found.component.html</context>
           <context context-type="linenumber">6</context>
         </context-group>
         <note priority="1" from="description">Title for 404 error page</note>
-      </trans-unit>
-      <trans-unit id="error404Text" datatype="html">
-        <source>Erreur 404</source>
+      </trans-unit><trans-unit id="error404Text" datatype="html">
+        <source>Erreur 404</source><target state="new">Fehler 404</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/page-not-found/page-not-found.component.html</context>
           <context context-type="linenumber">13</context>
         </context-group>
         <note priority="1" from="description">Text for 404 error</note>
-      </trans-unit>
-      <trans-unit id="homeLink" datatype="html">
-        <source>Accueil</source>
+      </trans-unit><trans-unit id="homeLink" datatype="html">
+        <source>Accueil</source><target state="new">Empfang</target>
         <context-group purpose="location">
           <context context-type="sourcefile">custom/footer/footer.html</context>
           <context context-type="linenumber">3</context>
         </context-group>
         <note priority="1" from="description">Home link</note>
-      </trans-unit>
-      <trans-unit id="aboutLink" datatype="html">
-        <source>A propos</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">custom/footer/footer.html</context>
-          <context context-type="linenumber">6</context>
-        </context-group>
+      </trans-unit><trans-unit id="aboutLink" datatype="html">
+        <source>A propos</source><target state="new">Über uns</target>
+        
         <note priority="1" from="description">About link</note>
-      </trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">custom/footer/footer.html</context><context context-type="linenumber">6</context></context-group></trans-unit>
       <trans-unit id="logout" datatype="html">
-        <source>Se déconnecter</source>
+        <source>Se déconnecter</source><target state="new">Abmelden</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/auth/logout/logout.component.html</context>
           <context context-type="linenumber">3</context>
@@ -1706,7 +1611,7 @@
         <note priority="1" from="meaning">logout</note>
       </trans-unit>
       <trans-unit id="home" datatype="html">
-        <source>Accueil</source>
+        <source>Accueil</source><target state="new">Empfang</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/core/topbar/topbar.component.html</context>
           <context context-type="linenumber">19</context>
@@ -1714,7 +1619,7 @@
         <note priority="1" from="description">home</note>
       </trans-unit>
       <trans-unit id="about" datatype="html">
-        <source>A propos</source>
+        <source>A propos</source><target state="new">Über uns</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/core/topbar/topbar.component.html</context>
           <context context-type="linenumber">33</context>
@@ -1723,7 +1628,8 @@
       </trans-unit>
       <trans-unit id="admin" datatype="html">
         <source>Admin
-                        </source>
+                        </source><target state="new">Admin
+                        </target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/core/topbar/topbar.component.html</context>
           <context context-type="linenumber">37</context>
@@ -1731,7 +1637,7 @@
         <note priority="1" from="description">admin</note>
       </trans-unit>
       <trans-unit id="validation" datatype="html">
-        <source>Validation</source>
+        <source>Validation</source><target state="new">Validierung</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/core/topbar/topbar.component.html</context>
           <context context-type="linenumber">43</context>
@@ -1739,43 +1645,52 @@
         <note priority="1" from="description">validation</note>
       </trans-unit>
       <trans-unit id="myDasboardLink" datatype="html">
-        <source>Mon tableau de bord</source>
+        <source>Mon tableau de bord</source><target state="new">Mein Dashboard</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/core/topbar/topbar.component.html</context>
           <context context-type="linenumber">54</context>
         </context-group>
         <note priority="1" from="description">my Dasboard Link</note>
-      </trans-unit>
-      <trans-unit id="myObservationsButton" datatype="html">
+      </trans-unit><trans-unit id="myObservationsButton" datatype="html">
         <source>
                             Mes observations
-                            <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/><x id="INTERPOLATION" equiv-text="{{
+                            <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong>"/><x id="INTERPOLATION" equiv-text="{{
                                 stats?.platform_attendance
-                                }}"/><x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/>
-                        </source>
+                                }}"/><x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong>"/>
+                        </source><target state="new">
+                            Meine Beobachtungen
+                            <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong>"/><x id="INTERPOLATION" equiv-text="{{
+                                stats?.platform_attendance
+                                }}"/><x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong>"/>
+                        </target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context>
           <context context-type="linenumber">13</context>
         </context-group>
         <note priority="1" from="description">Observations button</note>
-      </trans-unit>
-      <trans-unit id="mySitesButton" datatype="html">
+      </trans-unit><trans-unit id="mySitesButton" datatype="html">
         <source>
                             Mes sites
-                            <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/><x id="INTERPOLATION" equiv-text="{{
+                            <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong>"/><x id="INTERPOLATION" equiv-text="{{
                                 mysites?.features.length
-                                }}"/><x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/>
-                        </source>
+                                }}"/><x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong>"/>
+                        </source><target state="new">
+                            Meine Standorte
+                            <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong>"/><x id="INTERPOLATION" equiv-text="{{
+                                mysites?.features.length
+                                }}"/><x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong>"/>
+                        </target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context>
           <context context-type="linenumber">22</context>
         </context-group>
         <note priority="1" from="description">Sites button</note>
-      </trans-unit>
-      <trans-unit id="username" datatype="html">
+      </trans-unit><trans-unit id="username" datatype="html">
         <source>
-                        <x id="INTERPOLATION" equiv-text="{{ username }}"/> <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i&gt;"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i&gt;"/>
-                    </source>
+                        <x id="INTERPOLATION" equiv-text="{{ username }}"/> <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i>"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i>"/>
+                    </source><target state="new">
+                        <x id="INTERPOLATION" equiv-text="{{ username }}"/> <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i>"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i>"/>
+                    </target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context>
           <context context-type="linenumber">34</context>
@@ -1783,7 +1698,7 @@
         <note priority="1" from="description">Username</note>
       </trans-unit>
       <trans-unit id="myBadges" datatype="html">
-        <source>Mes badges</source>
+        <source>Mes badges</source><target state="new">Meine Abzeichen</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context>
           <context context-type="linenumber">40</context>
@@ -1793,23 +1708,23 @@
       <trans-unit id="generalAwards" datatype="html">
         <source>
                         Récompenses géneral
-                    </source>
+                    </source><target state="new">
+                        Allgemeine Belohnungen
+                    </target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context>
           <context context-type="linenumber">42</context>
         </context-group>
         <note priority="1" from="description">General Awards</note>
-      </trans-unit>
-      <trans-unit id="programAwards" datatype="html">
-        <source>Récompenses par programmes</source>
+      </trans-unit><trans-unit id="programAwards" datatype="html">
+        <source>Récompenses par programmes</source><target state="new">Programmbelohnungen</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context>
           <context context-type="linenumber">54</context>
         </context-group>
         <note priority="1" from="description">Program Awards</note>
-      </trans-unit>
-      <trans-unit id="recognitionAwards" datatype="html">
-        <source>Récompenses d&apos;identification d&apos;espèces</source>
+      </trans-unit><trans-unit id="recognitionAwards" datatype="html">
+        <source>Récompenses d'identification d'espèces</source><target state="new">Belohnungen für die Identifizierung von Arten</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context>
           <context context-type="linenumber">64</context>
@@ -1818,7 +1733,7 @@
       </trans-unit>
       <trans-unit id="exportPersonnalDataBtn" datatype="html">
         <source>Exporter mes données
-                        personnelles</source>
+                        personnelles</source><target state="new">Meine persönlichen Daten exportieren</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context>
           <context context-type="linenumber">82</context>
@@ -1827,7 +1742,7 @@
       </trans-unit>
       <trans-unit id="exportPersonnalObsBtn" datatype="html">
         <source>Exporter mes
-                        observations</source>
+                        observations</source><target state="new">Meine Beobachtungen exportieren</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context>
           <context context-type="linenumber">87</context>
@@ -1835,7 +1750,7 @@
         <note priority="1" from="description">Export personnal observations btn</note>
       </trans-unit>
       <trans-unit id="exportPersonnalSitesBtn" datatype="html">
-        <source>Exporter mes sites</source>
+        <source>Exporter mes sites</source><target state="new">Meine Standorte exportieren</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context>
           <context context-type="linenumber">92</context>
@@ -1844,15 +1759,14 @@
       </trans-unit>
       <trans-unit id="deleteAccount" datatype="html">
         <source>Supprimer mon
-                        compte</source>
+                        compte</source><target state="new">Mein Konto löschen</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context>
           <context context-type="linenumber">95</context>
         </context-group>
         <note priority="1" from="description">Delete Account</note>
-      </trans-unit>
-      <trans-unit id="backSite" datatype="html">
-        <source>Retour au site</source>
+      </trans-unit><trans-unit id="backSite" datatype="html">
+        <source>Retour au site</source><target state="new">Zurück zur standort</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context>
           <context context-type="linenumber">102</context>
@@ -1862,120 +1776,89 @@
       <trans-unit id="updatePersonnalData" datatype="html">
         <source>
             Mettre à jour vos données personnelles
-        </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context>
-          <context context-type="linenumber">111</context>
-        </context-group>
+        </source><target state="new">
+            Aktualisieren Sie Ihre persönlichen Daten
+        </target>
+        
         <note priority="1" from="description">Update personnal data</note>
-      </trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">111</context></context-group></trans-unit>
       <trans-unit id="yourUsernameInputPlaceholder" datatype="html">
-        <source>Entrez votre nom d&apos;utilisateur</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context>
-          <context context-type="linenumber">145</context>
-        </context-group>
+        <source>Entrez votre nom d'utilisateur</source><target state="new">Geben Sie Ihren Benutzernamen ein</target>
+        
         <note priority="1" from="description">
                                     your username
                                     placeholder</note>
-      </trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">145</context></context-group></trans-unit>
       <trans-unit id="yourEmailInputLabel" datatype="html">
-        <source>Votre email *</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context>
-          <context context-type="linenumber">151</context>
-        </context-group>
+        <source>Votre email *</source><target state="new">Ihre E-Mail *</target>
+        
         <note priority="1" from="description">your email label</note>
-      </trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">151</context></context-group></trans-unit>
       <trans-unit id="yourFirstnameInputLabel" datatype="html">
-        <source>Votre prénom *</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context>
-          <context context-type="linenumber">167</context>
-        </context-group>
+        <source>Votre prénom *</source><target state="new">Ihr Vorname *</target>
+        
         <note priority="1" from="description">your first name</note>
-      </trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">167</context></context-group></trans-unit>
       <trans-unit id="yourFirstnameInputPlaceholder" datatype="html">
-        <source>Entrez votre prénom</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context>
-          <context context-type="linenumber">171</context>
-        </context-group>
+        <source>Entrez votre prénom</source><target state="new">Geben Sie Ihren Vornamen ein</target>
+        
         <note priority="1" from="description">
                                 your first name
                                 placeholder</note>
-      </trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">171</context></context-group></trans-unit>
       <trans-unit id="yourSurnameInputLabel" datatype="html">
-        <source>Votre nom *</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context>
-          <context context-type="linenumber">176</context>
-        </context-group>
+        <source>Votre nom *</source><target state="new">Ihr Nachname *</target>
+        
         <note priority="1" from="description">your surname label</note>
-      </trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">176</context></context-group></trans-unit>
       <trans-unit id="yourSurnameInputPlaceholder" datatype="html">
-        <source>Entrez votre nom</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context>
-          <context context-type="linenumber">180</context>
-        </context-group>
+        <source>Entrez votre nom</source><target state="new">Geben Sie Ihren Nachnamen ein</target>
+        
         <note priority="1" from="description">
                                 your surname
                                 placeholder</note>
-      </trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">180</context></context-group></trans-unit>
       <trans-unit id="errorDifferentPasswords" datatype="html">
         <source>
                 Les mots de passe diffèrent.
-            </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context>
-          <context context-type="linenumber">188</context>
-        </context-group>
+            </source><target state="new">
+                Die Passwörter stimmen nicht überein.
+            </target>
+        
         <note priority="1" from="description">error different passwords</note>
-      </trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">188</context></context-group></trans-unit>
       <trans-unit id="yourPasswordLabel" datatype="html">
         <source>Votre nouveau mot de
-                            passe</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context>
-          <context context-type="linenumber">194</context>
-        </context-group>
+                            passe</source><target state="new">Ihr neues Passwort</target>
+        
         <note priority="1" from="description">your password label</note>
-      </trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">194</context></context-group></trans-unit>
       <trans-unit id="yourPasswordPlaceholder" datatype="html">
-        <source>Votre nouveau mot de passe</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context>
-          <context context-type="linenumber">199</context>
-        </context-group>
+        <source>Votre nouveau mot de passe</source><target state="new">Ihr neues Passwort</target>
+        
         <note priority="1" from="description">
                                 your password
                                 placeholder</note>
-      </trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">199</context></context-group></trans-unit>
       <trans-unit id="yourConfirmPasswordLabel" datatype="html">
-        <source>Confirmez votre nouveau mot de passe</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context>
-          <context context-type="linenumber">207</context>
-        </context-group>
+        <source>Confirmez votre nouveau mot de passe</source><target state="new">Bestätigen Sie Ihr neues Passwort</target>
+        
         <note priority="1" from="description">
                                 your password confirm
                                 label</note>
-      </trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">207</context></context-group></trans-unit>
       <trans-unit id="yourConfirmPasswordPlaceholder" datatype="html">
-        <source>Votre nouveau mot de passe</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context>
-          <context context-type="linenumber">211</context>
-        </context-group>
+        <source>Votre nouveau mot de passe</source><target state="new">Ihr neues Passwort</target>
+        
         <note priority="1" from="description">
                                 your password confirm
                                 placeholder</note>
-      </trans-unit>
-      <trans-unit id="passwordMismatch" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">211</context></context-group></trans-unit><trans-unit id="passwordMismatch" datatype="html">
         <source>
-                            * Le mot de passe n&apos;est pas identique.
-                        </source>
+                            * Le mot de passe n'est pas identique.
+                        </source><target state="new">
+                            * Das Passwort ist nicht identisch.
+                        </target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context>
           <context context-type="linenumber">217</context>
@@ -1985,126 +1868,111 @@
       <trans-unit id="updatePersonnalDataBtn" datatype="html">
         <source>
                 Mettre à jour
-            </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context>
-          <context context-type="linenumber">225</context>
-        </context-group>
+            </source><target state="new">
+                Aktualisieren
+            </target>
+        
         <note priority="1" from="description">update personnal data btn</note>
-      </trans-unit>
-      <trans-unit id="deleteObservationConfirmation" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">225</context></context-group></trans-unit><trans-unit id="deleteObservationConfirmation" datatype="html">
         <source>
         Êtes-vous sûr de vouloir supprimer cette observation ?
-        <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/&gt;"/>
+        <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/>"/>
         Sa suppression sera définitive
-    </source>
+    </source><target state="new">
+        Sind Sie sicher, dass Sie diese Beobachtung löschen möchten?
+        <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/>"/>
+        Die Löschung ist endgültig
+    </target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context>
           <context context-type="linenumber">236</context>
         </context-group>
         <note priority="1" from="description">Delete observation confirmation</note>
-      </trans-unit>
-      <trans-unit id="deleteSiteConfirmation" datatype="html">
+      </trans-unit><trans-unit id="deleteSiteConfirmation" datatype="html">
         <source>
         Êtes-vous sûr de vouloir supprimer ce site et toutes les informations
         qui y sont rattachées ?
-        <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/&gt;"/>
+        <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/>"/>
         La suppression sera définitive
-    </source>
+    </source><target state="new">
+        Sind Sie sicher, dass Sie diese Standort und alle damit verbundenen Informationen löschen möchten?
+        <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/>"/>
+        Die Löschung ist endgültig
+    </target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context>
           <context context-type="linenumber">255</context>
         </context-group>
         <note priority="1" from="description">Delete site confirmation</note>
-      </trans-unit>
-      <trans-unit id="proposedIdentification" datatype="html">
+      </trans-unit><trans-unit id="proposedIdentification" datatype="html">
         <source>
             Identification proposée : 
-            <x id="START_TAG_NG-CONTAINER" ctype="x-ng-container" equiv-text="&lt;ng-container&gt;"/><x id="INTERPOLATION" equiv-text="{{ obsToValidate.properties.nom_francais || obsToValidate.properties.taxref.nom_vern }}"/><x id="CLOSE_TAG_NG-CONTAINER" ctype="x-ng-container" equiv-text="&lt;/ng-container&gt;"/>
-            <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span&gt;"/>
-              (<x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i&gt;"/><x id="INTERPOLATION_1" equiv-text="{{ obsToValidate.properties.taxref.lb_nom }}"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i&gt;"/>)
-            <x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span&gt;"/>
-          </source>
+            <x id="START_TAG_NG-CONTAINER" ctype="x-ng-container" equiv-text="&lt;ng-container>"/><x id="INTERPOLATION" equiv-text="{{ obsToValidate.properties.nom_francais || obsToValidate.properties.taxref.nom_vern }}"/><x id="CLOSE_TAG_NG-CONTAINER" ctype="x-ng-container" equiv-text="&lt;/ng-container>"/>
+            <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span>"/>
+              (<x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i>"/><x id="INTERPOLATION_1" equiv-text="{{ obsToValidate.properties.taxref.lb_nom }}"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i>"/>)
+            <x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span>"/>
+          </source><target state="new">
+            Vorgeschlagene Identifizierung:
+            <x id="START_TAG_NG-CONTAINER" ctype="x-ng-container" equiv-text="&lt;ng-container>"/><x id="INTERPOLATION" equiv-text="{{ obsToValidate.properties.nom_francais || obsToValidate.properties.taxref.nom_vern }}"/><x id="CLOSE_TAG_NG-CONTAINER" ctype="x-ng-container" equiv-text="&lt;/ng-container>"/>
+            <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span>"/>
+              (<x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i>"/><x id="INTERPOLATION_1" equiv-text="{{ obsToValidate.properties.taxref.lb_nom }}"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i>"/>)
+            <x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span>"/>
+          </target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/observations/validation/validation.component.html</context>
           <context context-type="linenumber">30</context>
         </context-group>
         <note priority="1" from="description">Title for identification proposed</note>
-      </trans-unit>
-      <trans-unit id="speciesSearchOrValidation" datatype="html">
-        <source>{VAR_SELECT, select, isOn {Rechercher une espèce} isOff {Validez ou corrigez l&apos;espèce} }</source>
+      </trans-unit><trans-unit id="speciesSearchOrValidation" datatype="html">
+        <source>{VAR_SELECT, select, isOn {Rechercher une espèce} isOff {Validez ou corrigez l'espèce} }</source><target state="new">{VAR_SELECT, select, isOn {Eine Art suchen} isOff {Bestätigen oder korrigieren Sie die Art} }</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/observations/validation/validation.component.html</context>
           <context context-type="linenumber">39</context>
         </context-group>
         <note priority="1" from="description">Label for species search or validation</note>
-      </trans-unit>
-      <trans-unit id="notifyObserverLabel" datatype="html">
+      </trans-unit><trans-unit id="notifyObserverLabel" datatype="html">
         <source>
-                Avertir l&apos;observateur
-            </source>
+                Avertir l'observateur
+            </source><target state="new">
+                Den Beobachter benachrichtigen
+            </target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/observations/validation/validation.component.html</context>
           <context context-type="linenumber">128</context>
         </context-group>
         <note priority="1" from="description">Label for notifying the observer</note>
-      </trans-unit>
-      <trans-unit id="observerNotificationDescription" datatype="html">
-        <source>L&apos;observateur recevra un mail contenant des informations de validation,
-                correction ou d&apos;invalidité de son observation.</source>
+      </trans-unit><trans-unit id="observerNotificationDescription" datatype="html">
+        <source>L'observateur recevra un mail contenant des informations de validation,
+                correction ou d'invalidité de son observation.</source><target state="new">Der Beobachter erhält eine E-Mail mit Validierungsinformationen,
+                Korrektur oder Ungültigkeit seiner Beobachtung.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/observations/validation/validation.component.html</context>
           <context context-type="linenumber">131</context>
         </context-group>
         <note priority="1" from="description">Description for observer notification</note>
-      </trans-unit>
-      <trans-unit id="unvalidableObservationLabel" datatype="html">
+      </trans-unit><trans-unit id="unvalidableObservationLabel" datatype="html">
         <source>
-            Si l&apos;observation est non validable en l&apos;état :
-        </source>
+            Si l'observation est non validable en l'état :
+        </source><target state="new">
+            Wenn die Beobachtung in ihrem aktuellen Zustand nicht validierbar ist:
+        </target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/observations/validation/validation.component.html</context>
           <context context-type="linenumber">136</context>
         </context-group>
         <note priority="1" from="description">Label for unvalidable observation</note>
-      </trans-unit>
-      <trans-unit id="requestObserverModification" datatype="html">
-        <source>Demander à l&apos;observateur de modifier son observation ou a un autre
-                    validateur de la vérifier.</source>
+      </trans-unit><trans-unit id="requestObserverModification" datatype="html">
+        <source>Demander à l'observateur de modifier son observation ou a un autre
+                    validateur de la vérifier.</source><target state="new">Bitten Sie den Beobachter, seine Beobachtung zu ändern, oder einen anderen
+                    Validator, um es zu überprüfen.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/programs/observations/validation/validation.component.html</context>
           <context context-type="linenumber">146</context>
         </context-group>
         <note priority="1" from="description">Request for observer modification or validator check</note>
       </trans-unit>
-      <trans-unit id="obsActionBtn" datatype="html">
-        <source>
-            <x id="ICU" equiv-text="{ obsValidatable, select, true {...} false {...}}"/>
-        </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/programs/observations/validation/validation.component.html</context>
-          <context context-type="linenumber">154</context>
-        </context-group>
-        <note priority="1" from="description">Button for validating, correcting, or invalidating an observation</note>
-      </trans-unit>
-      <trans-unit id="a5cf87dd6048bc6d23f027b10d8a50f741000bc3" datatype="html">
-        <source>{VAR_SELECT_1, select, true {{VAR_SELECT, select, true {Corriger l&apos;observation} false {Valider l&apos;observation} }
-                    } false {Invalider l&apos;observation} }</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/programs/observations/validation/validation.component.html</context>
-          <context context-type="linenumber">155</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="discoverINPN" datatype="html">
-        <source>Découvrir sur INPN</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">app/synthesis/species/species.component.html</context>
-          <context context-type="linenumber">20</context>
-        </context-group>
-        <note priority="1" from="description">Link to INPN</note>
-      </trans-unit>
       <trans-unit id="redirectToHome" datatype="html">
-        <source>vous allez être redirigé automatiquement sur la page d&apos;accueil</source>
+        <source>vous allez être redirigé automatiquement sur la page d'accueil</source><target state="new">Sie werden automatisch auf die Startseite weitergeleitet</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/auth/confirm-email/confirm-email.component.html</context>
           <context context-type="linenumber">5</context>

--- a/frontend/src/i18n/messages.en.xlf
+++ b/frontend/src/i18n/messages.en.xlf
@@ -226,7 +226,7 @@
                 <note priority="1" from="description">Your pseudo</note>
 
 
-            <context-group purpose="location"><context context-type="sourcefile">app/auth/register/register.component.html</context><context context-type="linenumber">33</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">137</context></context-group></trans-unit>
+            <context-group purpose="location"><context context-type="sourcefile">app/auth/register/register.component.html</context><context context-type="linenumber">33</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">136</context></context-group></trans-unit>
             <trans-unit id="yourUsernameInputPlaceHolder" datatype="html">
                 <source>Entrez votre pseudonyme</source>
                 <target state="new">Enter your username</target>
@@ -255,7 +255,7 @@
                 <note priority="1" from="description">Your email input placeholder label</note>
 
 
-            <context-group purpose="location"><context context-type="sourcefile">app/auth/register/register.component.html</context><context context-type="linenumber">54</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">160</context></context-group></trans-unit>
+            <context-group purpose="location"><context context-type="sourcefile">app/auth/register/register.component.html</context><context context-type="linenumber">54</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">159</context></context-group></trans-unit>
             <trans-unit id="yourFirstNameLabel" datatype="html">
                 <source>Votre prénom</source>
                 <target state="new">Your first name</target>
@@ -357,7 +357,18 @@
                     <context context-type="sourcefile">app/auth/register/register.component.html</context>
                     <context context-type="linenumber">105</context>
                 </context-group>
-            </trans-unit>
+            </trans-unit><trans-unit id="invalidPasswordError" datatype="html">
+        <source>
+                        S'il vous plait entrez un mot de passe valide.
+                    </source><target state="new">
+                        Please provide a valid password.
+                    </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/auth/register/register.component.html</context>
+          <context context-type="linenumber">107</context>
+        </context-group>
+        <note priority="1" from="description">Error message for invalid password</note>
+      </trans-unit>
             <trans-unit id="acceptUGC" datatype="html">
                 <source>
                     Veuillez accepter les conditions d'utilisation.
@@ -371,7 +382,11 @@
                     <context context-type="sourcefile">app/auth/register/register.component.html</context>
                     <context context-type="linenumber">114</context>
                 </context-group>
-            </trans-unit>
+            </trans-unit><trans-unit id="iAcceptIntro" datatype="html">
+        <source>J'accepte les</source><target state="new">I accept</target>
+        
+        <note priority="1" from="description">I Accept</note>
+      <context-group purpose="location"><context context-type="sourcefile">app/auth/register/register.component.html</context><context context-type="linenumber">119</context></context-group></trans-unit>
             <trans-unit id="conditionsOfUse" datatype="html">
                 <source>conditions d'utilisation</source>
                 <target state="new">terms of use</target>
@@ -391,11 +406,8 @@
                 </target>
 
                 <note priority="1" from="description">register link</note>
-                <context-group purpose="location">
-                    <context context-type="sourcefile">app/auth/register/register.component.html</context>
-                    <context context-type="linenumber">132</context>
-                </context-group>
-            </trans-unit>
+                
+            <context-group purpose="location"><context context-type="sourcefile">app/auth/register/register.component.html</context><context context-type="linenumber">133</context></context-group></trans-unit>
             <trans-unit id="closeModal" datatype="html">
                 <source>
                     Fermer
@@ -409,7 +421,7 @@
 
 
 
-            <context-group purpose="location"><context context-type="sourcefile">app/auth/register/register.component.html</context><context context-type="linenumber">137</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/auth/login/login.component.html</context><context context-type="linenumber">163</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/programs/media-galery/media-galery.component.html</context><context context-type="linenumber">50</context></context-group></trans-unit>
+            <context-group purpose="location"><context context-type="sourcefile">app/auth/register/register.component.html</context><context context-type="linenumber">138</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/auth/login/login.component.html</context><context context-type="linenumber">163</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/programs/media-galery/media-galery.component.html</context><context context-type="linenumber">50</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/programs/base/detail/detail.component.html</context><context context-type="linenumber">172</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/programs/base/detail/detail.component.html</context><context context-type="linenumber">172</context></context-group></trans-unit>
             <trans-unit id="login" datatype="html">
                 <source>Se connecter</source>
                 <target state="new">SignIn</target>
@@ -512,7 +524,14 @@
 
 
                 <note priority="1" from="description">Add new obs</note>
-            <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/modalflow/steps/onboard/onboard.component.html</context><context context-type="linenumber">2</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/programs/observations/modalflow/steps/committed/committed.component.html</context><context context-type="linenumber">3</context></context-group></trans-unit>
+            <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/modalflow/steps/onboard/onboard.component.html</context><context context-type="linenumber">2</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/programs/observations/modalflow/steps/committed/committed.component.html</context><context context-type="linenumber">3</context></context-group></trans-unit><trans-unit id="whyRegisterHeading" datatype="html">
+        <source>Pourquoi s'inscrire ?</source><target state="new">Why register?</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/observations/modalflow/steps/onboard/onboard.component.html</context>
+          <context context-type="linenumber">14</context>
+        </context-group>
+        <note priority="1" from="description">Heading for why to register</note>
+      </trans-unit>
             <trans-unit id="registerAndContribute" datatype="html">
                 <source>S'incrire <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/>"/>et contribuer au site</source>
                 <target state="new">Register <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/>"/>and
@@ -537,7 +556,36 @@
 
                 <note priority="1" from="description">Invite to login</note>
 
-            <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/modalflow/steps/onboard/onboard.component.html</context><context context-type="linenumber">36</context></context-group></trans-unit>
+            <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/modalflow/steps/onboard/onboard.component.html</context><context context-type="linenumber">36</context></context-group></trans-unit><trans-unit id="speciesSearchSelectionLabel" datatype="html">
+        <source>{VAR_SELECT, select, isOn {Rechercher une espèce} isOff {Sélectionnez une espèce} }</source><target state="new">{VAR_SELECT, select, isOn {Search for a species} isOff {Select species} }</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/observations/form/form.component.html</context>
+          <context context-type="linenumber">26</context>
+        </context-group>
+        <note priority="1" from="description">Label for species search and selection</note>
+      </trans-unit><trans-unit id="chooseSpeciesOption" datatype="html">
+        <source>Choisissez une espèce</source><target state="new">Choose a species</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/observations/form/form.component.html</context>
+          <context context-type="linenumber">37</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/observations/validation/validation.component.html</context>
+          <context context-type="linenumber">49</context>
+        </context-group>
+        <note priority="1" from="description">Option to choose a species</note>
+      </trans-unit><trans-unit id="speciesNamePlaceholder" datatype="html">
+        <source>Nom latin ou vernaculaire ou cd_ref</source><target state="new">Latin or common name or cd_ref</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/observations/form/form.component.html</context>
+          <context context-type="linenumber">83</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/observations/validation/validation.component.html</context>
+          <context context-type="linenumber">95</context>
+        </context-group>
+        <note priority="1" from="description">Placeholder for species name input</note>
+      </trans-unit>
             <trans-unit id="additionalInfos" datatype="html">
                 <source>
                     Informations complémentaires
@@ -548,7 +596,7 @@
 
                 <note priority="1" from="description">Additional information</note>
 
-            <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">91</context></context-group></trans-unit>
+            <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">93</context></context-group></trans-unit>
             <trans-unit id="bservationDate" datatype="html">
                 <source>Date de l'observation</source>
                 <target state="new">Observation date</target>
@@ -556,7 +604,7 @@
                 <note priority="1" from="description">observation date</note>
 
 
-            <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">97</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/programs/observations/validation/validation.component.html</context><context context-type="linenumber">99</context></context-group></trans-unit>
+            <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">99</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/programs/observations/validation/validation.component.html</context><context context-type="linenumber">104</context></context-group></trans-unit>
             <trans-unit id="expectedDateFormat" datatype="html">
                 <source>jj/mm/aaaa</source>
                 <target state="new">jj/mm/aaaa</target>
@@ -564,14 +612,14 @@
                 <note priority="1" from="description">
                                 expected date format</note>
 
-            <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">99</context></context-group></trans-unit>
+            <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">101</context></context-group></trans-unit>
             <trans-unit id="enumerationInputLabel" datatype="html">
                 <source>Dénombrement</source>
                 <target state="new">Count</target>
 
                 <note priority="1" from="description">Enumeration Label</note>
 
-            <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">104</context></context-group></trans-unit>
+            <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">106</context></context-group></trans-unit>
             <trans-unit id="enumerationInputPlaceHolder" datatype="html">
                 <source>Nombre</source>
                 <target state="new">Number</target>
@@ -579,7 +627,7 @@
                 <note priority="1" from="description">
                             Enumeration Placeholder</note>
 
-            <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">106</context></context-group></trans-unit>
+            <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">108</context></context-group></trans-unit>
             <trans-unit id="commentInputLabel" datatype="html">
                 <source>Commentaire</source>
                 <target state="new">Comment</target>
@@ -587,7 +635,7 @@
                 <note priority="1" from="description">Comment Input Label</note>
 
 
-            <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">117</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/programs/observations/validation/validation.component.html</context><context context-type="linenumber">113</context></context-group></trans-unit>
+            <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">119</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/programs/observations/validation/validation.component.html</context><context context-type="linenumber">118</context></context-group></trans-unit>
             <trans-unit id="commentInputPlaceholder" datatype="html">
                 <source>Votre commentaire</source>
                 <target state="new">Your comment</target>
@@ -596,7 +644,7 @@
                         Comment Input Placeholder</note>
 
 
-            <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">119</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/programs/observations/validation/validation.component.html</context><context context-type="linenumber">116</context></context-group></trans-unit>
+            <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">121</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/programs/observations/validation/validation.component.html</context><context context-type="linenumber">121</context></context-group></trans-unit>
             <trans-unit id="existingPhotos" datatype="html">
                 <source>Photos existantes (cocher pour supprimer)</source>
                 <target state="new">Uploaded pictures (tick to delete)</target>
@@ -604,14 +652,14 @@
                 <note priority="1" from="description">Existing Photos</note>
 
 
-            <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">124</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/programs/sites/form/form.component.html</context><context context-type="linenumber">35</context></context-group></trans-unit>
+            <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">126</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/programs/sites/form/form.component.html</context><context context-type="linenumber">35</context></context-group></trans-unit>
             <trans-unit id="addPhoto" datatype="html">
                 <source>Ajouter une photo</source>
                 <target state="new">Add a photo</target>
 
                 <note priority="1" from="description">Add photo</note>
 
-            <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">132</context></context-group></trans-unit>
+            <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">134</context></context-group></trans-unit>
             <trans-unit id="obsLocation" datatype="html">
                 <source>
                     Où avez-vous observé cette espèce ?
@@ -622,7 +670,7 @@
 
                 <note priority="1" from="description">observation Location</note>
 
-            <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">140</context></context-group></trans-unit>
+            <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">142</context></context-group></trans-unit>
             <trans-unit id="ZoomToPointInstruction" datatype="html">
                 <source>
                         Veuillez zoomer pour localiser votre observation.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/>"/>
@@ -634,7 +682,7 @@
                 </target>
 
 
-            <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">145</context></context-group></trans-unit>
+            <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">147</context></context-group></trans-unit>
             <trans-unit id="zoomingInstruction" datatype="html">
                 <source>Veuillez zoomer pour localiser votre observation.</source>
                 <target state="new">Please zoom in to locate your observation.</target>
@@ -645,7 +693,7 @@
 
 
 
-            <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">158</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/programs/sites/siteform/siteform.component.html</context><context context-type="linenumber">28</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/programs/observations/validation/validation.component.html</context><context context-type="linenumber">110</context></context-group></trans-unit>
+            <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">160</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/programs/sites/siteform/siteform.component.html</context><context context-type="linenumber">33</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/programs/observations/validation/validation.component.html</context><context context-type="linenumber">115</context></context-group></trans-unit>
             <trans-unit id="clickOnMapInstruction" datatype="html">
                 <source>Cliquez sur
                     la carte pour renseigner le lieu
@@ -656,7 +704,7 @@
 
                 <note priority="1" from="description">click on map instruction</note>
 
-            <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">163</context></context-group></trans-unit>
+            <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">165</context></context-group></trans-unit>
             <trans-unit id="contactEmailInputLabel" datatype="html">
                 <source>E-mail de contact
                 </source>
@@ -665,7 +713,7 @@
 
                 <note priority="1" from="description">Contact email input label</note>
 
-            <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">178</context></context-group></trans-unit>
+            <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">180</context></context-group></trans-unit>
             <trans-unit id="contactEmailInputPlaceHolder" datatype="html">
                 <source>E-Mail</source>
                 <target state="new">E-Mail</target>
@@ -674,7 +722,7 @@
                         Contact email input
                         placeholder</note>
 
-            <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">182</context></context-group></trans-unit>
+            <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">184</context></context-group></trans-unit>
             <trans-unit id="missingFieldsAlert" datatype="html">
                 <source>
                     Champs manquants
@@ -685,7 +733,7 @@
 
                 <note priority="1" from="description">Missing fields alert</note>
 
-            <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">189</context></context-group></trans-unit>
+            <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">191</context></context-group></trans-unit>
             <trans-unit id="updateObs" datatype="html">
                 <source>
                     MODIFIER L'OBSERVATION
@@ -699,7 +747,14 @@
 
 
 
-            <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/modalflow/steps/committed/committed.component.html</context><context context-type="linenumber">6</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/programs/observations/obs.component.html</context><context context-type="linenumber">74</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/programs/observations/obs.component.html</context><context context-type="linenumber">74</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/programs/observations/obs.component.html</context><context context-type="linenumber">74</context></context-group></trans-unit>
+            <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/modalflow/steps/committed/committed.component.html</context><context context-type="linenumber">6</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/programs/observations/obs.component.html</context><context context-type="linenumber">72</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/programs/observations/obs.component.html</context><context context-type="linenumber">72</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/programs/observations/obs.component.html</context><context context-type="linenumber">72</context></context-group></trans-unit><trans-unit id="informationHeading" datatype="html">
+        <source>Information</source><target state="new">Information</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/observations/modalflow/steps/committed/committed.component.html</context>
+          <context context-type="linenumber">20</context>
+        </context-group>
+        <note priority="1" from="description">Heading for information section</note>
+      </trans-unit>
             <trans-unit id="validObsBtn" datatype="html">
                 <source>
                     Valider l'observation
@@ -711,7 +766,7 @@
                 <note priority="1" from="description">Valid obs btn</note>
 
 
-            <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/modalflow/steps/committed/committed.component.html</context><context context-type="linenumber">32</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/programs/observations/validation/validation.component.html</context><context context-type="linenumber">149</context></context-group></trans-unit>
+            <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/modalflow/steps/committed/committed.component.html</context><context context-type="linenumber">32</context></context-group></trans-unit>
             <trans-unit id="updateObsBtn" datatype="html">
                 <source>
                     Modifier l'observation
@@ -734,7 +789,7 @@
                 <note priority="1" from="description">Cancel</note>
 
 
-            <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/modalflow/steps/committed/committed.component.html</context><context context-type="linenumber">40</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/programs/observations/validation/validation.component.html</context><context context-type="linenumber">153</context></context-group></trans-unit>
+            <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/modalflow/steps/committed/committed.component.html</context><context context-type="linenumber">40</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/programs/base/detail/detail.component.html</context><context context-type="linenumber">193</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/programs/base/detail/detail.component.html</context><context context-type="linenumber">193</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">242</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">262</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/programs/observations/validation/validation.component.html</context><context context-type="linenumber">166</context></context-group></trans-unit>
             <trans-unit id="congrats" datatype="html">
                 <source>Félicitations !</source>
                 <target state="new">Congratulations!</target>
@@ -754,7 +809,7 @@
 
                 <note priority="1" from="description">Congrats message</note>
 
-            <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/modalflow/steps/congrats/congrats.component.html</context><context context-type="linenumber">17</context></context-group></trans-unit>
+            <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/modalflow/steps/congrats/congrats.component.html</context><context context-type="linenumber">17</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/programs/sites/modalflow/steps/congrats/congrats.component.html</context><context context-type="linenumber">5</context></context-group></trans-unit>
             <trans-unit id="obsDateObserver" datatype="html">
                 <source>Observé par <x id="INTERPOLATION" equiv-text="{{ username || 'Anonyme' }}"/> <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/>"/>
         le <x id="INTERPOLATION_1" equiv-text="{{ obs.date }}"/></source>
@@ -777,18 +832,55 @@
             <trans-unit id="ab0413f2974d14060a3f1b621ef18bd194be83ad" datatype="html">
                 <source>{VAR_PLURAL, plural, =1 {Vous venez d'obtenir
             ce badge } other {Vous venez d'obtenir ces badges } }</source>
-                <target state="new">{VAR_PLURAL, plural, =1 {Vous venez d'obtenir
-                    ce badge } other {Vous venez d'obtenir ces badges } }</target>
+                <target state="new">{VAR_PLURAL, plural, =1 {You have just obtained
+                    this badge } other {You have just obtained these badges } }</target>
 
 
-            <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/modalflow/steps/reward/reward.component.html</context><context context-type="linenumber">8</context></context-group></trans-unit>
+            <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/modalflow/steps/reward/reward.component.html</context><context context-type="linenumber">8</context></context-group></trans-unit><trans-unit id="zoomWarning" datatype="html">
+        <source>Veuillez zoomer pour localiser votre observation.</source><target state="new">Please zoom in to locate your sighting.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/observations/map/map.component.html</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+        <note priority="1" from="description">Warning message for zoom on observation map</note>
+      </trans-unit><trans-unit id="observationDetailsLink" datatype="html">
+        <source><x id="START_LINK" ctype="x-a" equiv-text="&lt;a>"/><x id="INTERPOLATION" equiv-text="{{ m.name }}"/> le <x id="INTERPOLATION_1" equiv-text="{{ m.date | date: 'longDate' }}"/><x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/> par @<x id="INTERPOLATION_2" equiv-text="{{
+                    m.observer
+                    }}"/>
+                </source><target state="new"><x id="START_LINK" ctype="x-a" equiv-text="&lt;a>"/><x id="INTERPOLATION" equiv-text="{{ m.name }}"/> on <x id="INTERPOLATION_1" equiv-text="{{ m.date | date: 'longDate' }}"/><x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/> by @<x id="INTERPOLATION_2" equiv-text="{{
+                    m.observer
+                    }}"/>
+                </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/media-galery/media-galery.component.html</context>
+          <context context-type="linenumber">7</context>
+        </context-group>
+        <note priority="1" from="description">Link text for observation details</note>
+      </trans-unit>
             <trans-unit id="NoMediasInfo" datatype="html">
                 <source>Aucune photo</source>
                 <target state="new">No photo</target>
 
                 <note priority="1" from="description">No medias</note>
 
-            <context-group purpose="location"><context context-type="sourcefile">app/programs/media-galery/media-galery.component.html</context><context context-type="linenumber">18</context></context-group></trans-unit>
+            <context-group purpose="location"><context context-type="sourcefile">app/programs/media-galery/media-galery.component.html</context><context context-type="linenumber">18</context></context-group></trans-unit><trans-unit id="clickedPhotoModalTitle" datatype="html">
+        <source>
+                    <x id="INTERPOLATION" equiv-text="{{ clickedPhoto.name }}"/> le
+                    <x id="INTERPOLATION_1" equiv-text="{{ clickedPhoto.date | date: 'longDate' }}"/> par @<x id="INTERPOLATION_2" equiv-text="{{
+                    clickedPhoto.observer
+                    }}"/>
+                </source><target state="new">
+                    <x id="INTERPOLATION" equiv-text="{{ clickedPhoto.name }}"/> on
+                    <x id="INTERPOLATION_1" equiv-text="{{ clickedPhoto.date | date: 'longDate' }}"/> by @<x id="INTERPOLATION_2" equiv-text="{{
+                    clickedPhoto.observer
+                    }}"/>
+                </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/media-galery/media-galery.component.html</context>
+          <context context-type="linenumber">28</context>
+        </context-group>
+        <note priority="1" from="description">Modal title for clicked photo</note>
+      </trans-unit>
             <trans-unit id="allSpeciesSelectOption" datatype="html">
                 <source>Toutes espèces</source>
                 <target state="new">All species</target>
@@ -825,14 +917,608 @@
 
                 <note priority="1" from="description">My obs</note>
 
-            <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/list/list.component.html</context><context context-type="linenumber">43</context></context-group></trans-unit>
+            <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/list/list.component.html</context><context context-type="linenumber">43</context></context-group></trans-unit><trans-unit id="observationWithPhotoTooltip" datatype="html">
+        <source>Observation avec photo</source><target state="new">Observation with photo</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/observations/list/list.component.html</context>
+          <context context-type="linenumber">70</context>
+        </context-group>
+        <note priority="1" from="description">Tooltip for observation with photo</note>
+      </trans-unit><trans-unit id="nonValidatedObservationTooltip" datatype="html">
+        <source>Observation non validée<x id="INTERPOLATION" equiv-text="{{o.properties.observer?.username == username ? ' - Validation par un tiers requise' : ''}}"/></source><target state="new">Non-validated observation<x id="INTERPOLATION" equiv-text="{{o.properties.observer?.username == username ? ' - Validation by a third party required' : ''}}"/></target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/observations/list/list.component.html</context>
+          <context context-type="linenumber">104</context>
+        </context-group>
+        <note priority="1" from="description">Tooltip for non-validated observation</note>
+      </trans-unit><trans-unit id="invalidObservationTooltip" datatype="html">
+        <source>Observation invalide<x id="INTERPOLATION" equiv-text="{{o.properties.observer?.username == username ? ' - Validation par un tiers requise' : ''}}"/></source><target state="new">Invalid observation<x id="INTERPOLATION" equiv-text="{{o.properties.observer?.username == username ? ' - Validation by a third party required' : ''}}"/></target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/observations/list/list.component.html</context>
+          <context context-type="linenumber">109</context>
+        </context-group>
+        <note priority="1" from="description">Tooltip for invalid observation</note>
+      </trans-unit><trans-unit id="nonValidatableObservationTooltip" datatype="html">
+        <source>Observation non validable<x id="INTERPOLATION" equiv-text="{{o.properties.observer?.username == username ? ' - Validation par un tiers requise' : ''}}"/></source><target state="new">Non-valid observation<x id="INTERPOLATION" equiv-text="{{o.properties.observer?.username == username ? ' - Validation by a third party required' : ''}}"/></target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/observations/list/list.component.html</context>
+          <context context-type="linenumber">114</context>
+        </context-group>
+        <note priority="1" from="description">Tooltip for non-validatable observation</note>
+      </trans-unit><trans-unit id="validatedObservationTooltip" datatype="html">
+        <source>Observation approuvée</source><target state="new">Approved observation</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/observations/list/list.component.html</context>
+          <context context-type="linenumber">119</context>
+        </context-group>
+        <note priority="1" from="description">Tooltip for validated observation</note>
+      </trans-unit><trans-unit id="editButtonTooltip" datatype="html">
+        <source>Editer</source><target state="new">Edit</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/observations/list/list.component.html</context>
+          <context context-type="linenumber">146</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/sites/list/list.component.html</context>
+          <context context-type="linenumber">24</context>
+        </context-group>
+        <note priority="1" from="description">Tooltip for edit button</note>
+      </trans-unit><trans-unit id="deleteButtonTooltip" datatype="html">
+        <source>Supprimer</source><target state="new">Delete</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/observations/list/list.component.html</context>
+          <context context-type="linenumber">150</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/sites/list/list.component.html</context>
+          <context context-type="linenumber">31</context>
+        </context-group>
+        <note priority="1" from="description">Tooltip for delete button</note>
+      </trans-unit><trans-unit id="datePrefix" datatype="html">
+        <source>le</source><target state="new">on</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/observations/list/list.component.html</context>
+          <context context-type="linenumber">157</context>
+        </context-group>
+        <note priority="1" from="description">Date prefix</note>
+      </trans-unit><trans-unit id="locationPrefix" datatype="html">
+        <source>à</source><target state="new">at</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/observations/list/list.component.html</context>
+          <context context-type="linenumber">160</context>
+        </context-group>
+        <note priority="1" from="description">Location prefix</note>
+      </trans-unit><trans-unit id="viewObservationDetailsTooltip" datatype="html">
+        <source>Voir les détails de cette observation</source><target state="new">View the details of this observation</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/observations/list/list.component.html</context>
+          <context context-type="linenumber">171</context>
+        </context-group>
+        <note priority="1" from="description">Tooltip for viewing observation details</note>
+      </trans-unit><trans-unit id="addButtonText" datatype="html">
+        <source>Ajouter</source><target state="new">Add</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/observations/obs.component.html</context>
+          <context context-type="linenumber">47</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/sites/sites.component.html</context>
+          <context context-type="linenumber">75</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/sites/sites.component.html</context>
+          <context context-type="linenumber">82</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/observations/obs.component.html</context>
+          <context context-type="linenumber">47</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/observations/obs.component.html</context>
+          <context context-type="linenumber">47</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/sites/sites.component.html</context>
+          <context context-type="linenumber">75</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/sites/sites.component.html</context>
+          <context context-type="linenumber">82</context>
+        </context-group>
+        <note priority="1" from="description">Add button text</note>
+      </trans-unit><trans-unit id="addObservationTooltip" datatype="html">
+        <source>Ajouter une observation</source><target state="new">Add an observation</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/observations/obs.component.html</context>
+          <context context-type="linenumber">45</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/observations/obs.component.html</context>
+          <context context-type="linenumber">45</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/observations/obs.component.html</context>
+          <context context-type="linenumber">45</context>
+        </context-group>
+        <note priority="1" from="description">Ajouter une observation</note>
+      </trans-unit><trans-unit id="informations" datatype="html">
+        <source>Informations</source><target state="new">Information</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/sites/siteform/siteform.component.html</context>
+          <context context-type="linenumber">5</context>
+        </context-group>
+        <note priority="1" from="description">Informations</note>
+      </trans-unit><trans-unit id="siteTypeLabel" datatype="html">
+        <source>Type de site</source><target state="new">Site type</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/sites/siteform/siteform.component.html</context>
+          <context context-type="linenumber">8</context>
+        </context-group>
+        <note priority="1" from="description">Libellé pour le champ Type de site</note>
+      </trans-unit><trans-unit id="siteNameLabel" datatype="html">
+        <source>Nom du site</source><target state="new">Site name</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/sites/siteform/siteform.component.html</context>
+          <context context-type="linenumber">25</context>
+        </context-group>
+        <note priority="1" from="description">Libellé pour le champ Nom du site</note>
+      </trans-unit><trans-unit id="locationSiteQuestion" datatype="html">
+        <source>Où est-il situé ?</source><target state="new">Where is it located?</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/sites/siteform/siteform.component.html</context>
+          <context context-type="linenumber">30</context>
+        </context-group>
+        <note priority="1" from="description">Question localisation site</note>
+      </trans-unit>
             <trans-unit id="zoomingWarning" datatype="html">
                 <source>Veuillez zoomer pour localiser votre observation.</source>
                 <target state="new">Please zoom in to locate your observation.</target>
 
                 <note priority="1" from="description">Zooming warning</note>
 
-            <context-group purpose="location"><context context-type="sourcefile">app/programs/sites/siteform/siteform.component.html</context><context context-type="linenumber">45</context></context-group></trans-unit>
+            <context-group purpose="location"><context context-type="sourcefile">app/programs/sites/siteform/siteform.component.html</context><context context-type="linenumber">50</context></context-group></trans-unit><trans-unit id="addSiteTitle" datatype="html">
+        <source>AJOUTER UN SITE</source><target state="new">ADD A SITE</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/sites/modalflow/steps/site/site_step.component.html</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+        <note priority="1" from="description">Title for add site</note>
+      </trans-unit><trans-unit id="validSiteButton" datatype="html">
+        <source>
+        Valider le site
+    </source><target state="new">
+        Validate the site
+    </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/sites/modalflow/steps/site/site_step.component.html</context>
+          <context context-type="linenumber">29</context>
+        </context-group>
+        <note priority="1" from="description">button valid site</note>
+      </trans-unit><trans-unit id="stepTitle" datatype="html">
+        <source>
+            Etape <x id="INTERPOLATION" equiv-text="{{ currentStep }}"/>/<x id="INTERPOLATION_1" equiv-text="{{ totalSteps() }}"/> :
+            <x id="INTERPOLATION_2" equiv-text="{{ jsonSchema.steps[currentStep - 1].title }}"/>
+        </source><target state="new">
+            Step <x id="INTERPOLATION" equiv-text="{{ currentStep }}"/>/<x id="INTERPOLATION_1" equiv-text="{{ totalSteps() }}"/> :
+            <x id="INTERPOLATION_2" equiv-text="{{ jsonSchema.steps[currentStep - 1].title }}"/>
+        </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/sites/form/form.component.html</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+        <note priority="1" from="description">Step Title</note>
+      </trans-unit><trans-unit id="visitDate" datatype="html">
+        <source>Date de la visite</source><target state="new">Visit date</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/sites/form/form.component.html</context>
+          <context context-type="linenumber">13</context>
+        </context-group>
+        <note priority="1" from="description">Visit Date</note>
+      </trans-unit><trans-unit id="dateRequired" datatype="html">
+        <source>
+                            La date est obligatoire
+                        </source><target state="new">
+                            The date is required
+                        </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/sites/form/form.component.html</context>
+          <context context-type="linenumber">17</context>
+        </context-group>
+        <note priority="1" from="description">Date Required</note>
+      </trans-unit><trans-unit id="futureDateError" datatype="html">
+        <source>
+                            La date doit être antérieure à la date du jour
+                        </source><target state="new">
+                            The date must be before today's date
+                        </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/sites/form/form.component.html</context>
+          <context context-type="linenumber">24</context>
+        </context-group>
+        <note priority="1" from="description">Message d'erreur pour une date future</note>
+      </trans-unit><trans-unit id="invalidDateError" datatype="html">
+        <source>
+                            Date invalide
+                        </source><target state="new">
+                            Invalid date
+                        </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/sites/form/form.component.html</context>
+          <context context-type="linenumber">27</context>
+        </context-group>
+        <note priority="1" from="description">Message d'erreur pour une date invalide</note>
+      </trans-unit><trans-unit id="addSiteVisitReportTitle" datatype="html">
+        <source>AJOUTER UN RAPPORT DE VISITE</source><target state="new">ADD A VISIT REPORT</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/sites/modalflow/steps/visit/visit_step.component.html</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+        <note priority="1" from="description">Modal title for adding a site visit report</note>
+      </trans-unit><trans-unit id="previousStep" datatype="html">
+        <source>
+        Etape précédente
+    </source><target state="new">
+        Previous step
+    </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/sites/modalflow/steps/visit/visit_step.component.html</context>
+          <context context-type="linenumber">28</context>
+        </context-group>
+        <note priority="1" from="description">Previous Step</note>
+      </trans-unit><trans-unit id="nextStep" datatype="html">
+        <source>
+        Etape suivante
+    </source><target state="new">
+        Next step
+    </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/sites/modalflow/steps/visit/visit_step.component.html</context>
+          <context context-type="linenumber">37</context>
+        </context-group>
+        <note priority="1" from="description">Next Step</note>
+      </trans-unit><trans-unit id="validVisitButton" datatype="html">
+        <source>
+        Valider la visite
+    </source><target state="new">
+        Validate the visit
+    </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/sites/modalflow/steps/visit/visit_step.component.html</context>
+          <context context-type="linenumber">47</context>
+        </context-group>
+        <note priority="1" from="description">button valid visit</note>
+      </trans-unit><trans-unit id="congratsTitle" datatype="html">
+        <source>Félicitations !</source><target state="new">Congratulations!</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/sites/modalflow/steps/congrats/congrats.component.html</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+        <note priority="1" from="description">Félicitations</note>
+      </trans-unit><trans-unit id="mySitesTitle" datatype="html">
+        <source>Mes Sites </source><target state="new">My Sites </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/sites/list/list.component.html</context>
+          <context context-type="linenumber">6</context>
+        </context-group>
+        <note priority="1" from="description">Titre pour Mes Sites</note>
+      </trans-unit><trans-unit id="addedMessage" datatype="html">
+        <source>
+                            <x id="START_TAG_NG-CONTAINER" ctype="x-ng-container" equiv-text="&lt;ng-container>"/><x id="INTERPOLATION" equiv-text="{{ o.properties.site_type.type | titlecase }}"/><x id="CLOSE_TAG_NG-CONTAINER" ctype="x-ng-container" equiv-text="&lt;/ng-container>"/> ajouté(e) par <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span>"/><x id="INTERPOLATION_1" equiv-text="{{ o.properties.obs_txt }}"/><x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span>"/>
+                        </source><target state="new">
+                            <x id="START_TAG_NG-CONTAINER" ctype="x-ng-container" equiv-text="&lt;ng-container>"/><x id="INTERPOLATION" equiv-text="{{ o.properties.site_type.type | titlecase }}"/><x id="CLOSE_TAG_NG-CONTAINER" ctype="x-ng-container" equiv-text="&lt;/ng-container>"/> added by <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span>"/><x id="INTERPOLATION_1" equiv-text="{{ o.properties.obs_txt }}"/><x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span>"/>
+                        </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/sites/list/list.component.html</context>
+          <context context-type="linenumber">41</context>
+        </context-group>
+        <note priority="1" from="description">Message d'ajout</note>
+      </trans-unit><trans-unit id="dateDeterminer" datatype="html">
+        <source>le</source><target state="new">on</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/sites/list/list.component.html</context>
+          <context context-type="linenumber">46</context>
+        </context-group>
+        <note priority="1" from="description">Déterminant pour une date</note>
+      </trans-unit><trans-unit id="addSiteButton" datatype="html">
+        <source>Ajouter</source><target state="new">Add</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/sites/sites.component.html</context>
+          <context context-type="linenumber">45</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/sites/sites.component.html</context>
+          <context context-type="linenumber">45</context>
+        </context-group>
+        <note priority="1" from="description">Add site button text</note>
+      </trans-unit><trans-unit id="addSiteTooltip" datatype="html">
+        <source>Ajouter un site</source><target state="new">Add site</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/sites/sites.component.html</context>
+          <context context-type="linenumber">44</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/sites/sites.component.html</context>
+          <context context-type="linenumber">44</context>
+        </context-group>
+        <note priority="1" from="description">Tooltip for adding a site</note>
+      </trans-unit><trans-unit id="backToProgramLink" datatype="html">
+        <source>
+            <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i>"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i>"/>
+            Retour au programme</source><target state="new">
+            <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i>"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i>"/>
+            Back to the program</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+        <note priority="1" from="description">Link to go back to the program</note>
+      </trans-unit><trans-unit id="addedDateObserverText" datatype="html">
+        <source>Ajoutée le
+                    <x id="INTERPOLATION" equiv-text="{{ (module === 'sites' ? site?.properties.timestamp_create.substring(0, 10) :
+                    obs?.properties.timestamp_create.substring(0, 10))
+                    | date: 'longDate'
+                    }}"/>
+                    par <x id="INTERPOLATION_1" equiv-text="{{ module === 'sites' ? site?.properties.obs_txt: obs?.properties.obs_txt }}"/></source><target state="new">Added on
+                    <x id="INTERPOLATION" equiv-text="{{ (module === 'sites' ? site?.properties.timestamp_create.substring(0, 10) :
+                    obs?.properties.timestamp_create.substring(0, 10))
+                    | date: 'longDate'
+                    }}"/>
+                    by <x id="INTERPOLATION_1" equiv-text="{{ module === 'sites' ? site?.properties.obs_txt: obs?.properties.obs_txt }}"/></target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">19</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">19</context>
+        </context-group>
+        <note priority="1" from="description">Text for added date and observer</note>
+      </trans-unit><trans-unit id="singleSiteVisitText" datatype="html">
+        <source>
+                            Visite du
+                            <x id="INTERPOLATION" equiv-text="{{
+                            site?.properties.visits[0].date
+                            | date: 'longDate'
+                            }}"/>
+                        </source><target state="new">
+                            Visit on
+                            <x id="INTERPOLATION" equiv-text="{{
+                            site?.properties.visits[0].date
+                            | date: 'longDate'
+                            }}"/>
+                        </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">40</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">40</context>
+        </context-group>
+        <note priority="1" from="description">Text for a single site visit date</note>
+      </trans-unit><trans-unit id="noVisitsMessage" datatype="html">
+        <source>Aucune visite enregistrée :(</source><target state="new">No visits recorded :(</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">54</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">54</context>
+        </context-group>
+        <note priority="1" from="description">No visits recorded message</note>
+      </trans-unit><trans-unit id="addSiteVisitReportButton" datatype="html">
+        <source>Ajouter un rapport
+                    de visite</source><target state="new">Add a visit report</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">58</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">58</context>
+        </context-group>
+        <note priority="1" from="description">Button to add a site visit report</note>
+      </trans-unit><trans-unit id="observationCardTitle" datatype="html">
+        <source>Observation #<x id="INTERPOLATION" equiv-text="{{ obs_id }}"/></source><target state="new">Observation #<x id="INTERPOLATION" equiv-text="{{ obs_id }}"/></target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">65</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">65</context>
+        </context-group>
+        <note priority="1" from="description">Observation card title with ID</note>
+      </trans-unit><trans-unit id="observerLabel" datatype="html">
+        <source>Observateur :</source><target state="new">Observer:</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">67</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">67</context>
+        </context-group>
+        <note priority="1" from="description">Observer label</note>
+      </trans-unit><trans-unit id="dateLabel" datatype="html">
+        <source>Date :</source><target state="new">Date:</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">68</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">68</context>
+        </context-group>
+        <note priority="1" from="description">Date label</note>
+      </trans-unit><trans-unit id="municipalityLabel" datatype="html">
+        <source>Commune :</source><target state="new">Municipality:</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">70</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">70</context>
+        </context-group>
+        <note priority="1" from="description">Municipality label</note>
+      </trans-unit><trans-unit id="countLabel" datatype="html">
+        <source>Nombre :</source><target state="new">Count:</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">72</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">72</context>
+        </context-group>
+        <note priority="1" from="description">Count label</note>
+      </trans-unit><trans-unit id="photosSectionTitle" datatype="html">
+        <source>Photos</source><target state="new">Photos</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">84</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">84</context>
+        </context-group>
+        <note priority="1" from="description">Section title for photos</note>
+      </trans-unit><trans-unit id="photoDateAuthorLabel" datatype="html">
+        <source>Le <x id="INTERPOLATION" equiv-text="{{ photo.date | date: 'longDate' }}"/> par <x id="INTERPOLATION_1" equiv-text="{{ photo.author }}"/></source><target state="new">On <x id="INTERPOLATION" equiv-text="{{ photo.date | date: 'longDate' }}"/> by <x id="INTERPOLATION_1" equiv-text="{{ photo.author }}"/></target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">93</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">93</context>
+        </context-group>
+        <note priority="1" from="description">Photo date and author label</note>
+      </trans-unit><trans-unit id="descriptionSectionTitle" datatype="html">
+        <source>Description</source><target state="new">Description</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">101</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">138</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">101</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">138</context>
+        </context-group>
+        <note priority="1" from="description">Section title for description</note>
+      </trans-unit><trans-unit id="siteVisitDateAuthor" datatype="html">
+        <source>
+                <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i>"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i>"/>
+                <x id="INTERPOLATION" equiv-text="{{ a.date | date: 'longDate' }}"/> par <x id="INTERPOLATION_1" equiv-text="{{ a.author }}"/>
+                <x id="START_ITALIC_TEXT_1" ctype="x-i" equiv-text="&lt;i>"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i>"/>
+                 
+                <x id="START_ITALIC_TEXT_2" ctype="x-i" equiv-text="&lt;i>"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i>"/>
+            </source><target state="new">
+                <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i>"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i>"/>
+                <x id="INTERPOLATION" equiv-text="{{ a.date | date: 'longDate' }}"/> by <x id="INTERPOLATION_1" equiv-text="{{ a.author }}"/>
+                <x id="START_ITALIC_TEXT_1" ctype="x-i" equiv-text="&lt;i>"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i>"/>
+                 
+                <x id="START_ITALIC_TEXT_2" ctype="x-i" equiv-text="&lt;i>"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i>"/>
+            </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">106</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">106</context>
+        </context-group>
+        <note priority="1" from="description">Date and author for site visit</note>
+      </trans-unit><trans-unit id="editSiteVisitTooltip" datatype="html">
+        <source>Editer</source><target state="new">Edit</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">109</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">109</context>
+        </context-group>
+        <note priority="1" from="description">Tooltip for edit site visit</note>
+      </trans-unit><trans-unit id="deleteSiteVisitTooltip" datatype="html">
+        <source>Supprimer</source><target state="new">Delete</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">113</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">113</context>
+        </context-group>
+        <note priority="1" from="description">Tooltip for delete site visit</note>
+      </trans-unit><trans-unit id="noDataMessage" datatype="html">
+        <source>Aucune donnée</source><target state="new">No data</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">128</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">128</context>
+        </context-group>
+        <note priority="1" from="description">No data available message</note>
+      </trans-unit><trans-unit id="deleteSiteVisitConfirmation" datatype="html">
+        <source>
+        Êtes-vous sûr de vouloir supprimer cette visite et toutes les informations
+        qui y sont rattachées ?
+        <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/>"/>
+        La suppression sera définitive
+    </source><target state="new">
+        Are you sure you want to delete this visit and all related information?
+        <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/>"/>
+        The deletion will be permanent
+    </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">185</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">185</context>
+        </context-group>
+        <note priority="1" from="description">Confirmation message for deleting a site visit</note>
+      </trans-unit><trans-unit id="yes" datatype="html">
+        <source>
+            OUI
+        </source><target state="new">
+            YES
+        </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">197</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">197</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context>
+          <context context-type="linenumber">245</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context>
+          <context context-type="linenumber">265</context>
+        </context-group>
+        <note priority="1" from="description">Yes</note>
+      </trans-unit>
             <trans-unit id="scrollForMore" datatype="html">
                 <source>Scrollez pour en voir plus !</source>
                 <target state="new">Scroll down to see more!</target>
@@ -858,52 +1544,62 @@
                 <target state="new">Species</target>
 
                 <note priority="1" from="description">species</note>
-                <context-group purpose="location">
-                    <context context-type="sourcefile">app/home/home.component.html</context>
-                    <context context-type="linenumber">27</context>
-                </context-group>
-            </trans-unit>
+                
+            <context-group purpose="location"><context context-type="sourcefile">app/home/home.component.html</context><context context-type="linenumber">27</context></context-group></trans-unit>
             <trans-unit id="observers" datatype="html">
                 <source>Observateurs</source>
                 <target state="new">Observers</target>
 
                 <note priority="1" from="description">Observers</note>
-                <context-group purpose="location">
-                    <context context-type="sourcefile">app/home/home.component.html</context>
-                    <context context-type="linenumber">36</context>
-                </context-group>
-            </trans-unit>
+                
+            <context-group purpose="location"><context context-type="sourcefile">app/home/home.component.html</context><context context-type="linenumber">36</context></context-group></trans-unit>
             <trans-unit id="momenPrograms" datatype="html">
                 <source>Les programmes du moment</source>
                 <target state="new">Current programs</target>
 
                 <note priority="1" from="description">Programs of the moment</note>
-                <context-group purpose="location">
-                    <context context-type="sourcefile">app/home/home.component.html</context>
-                    <context context-type="linenumber">98</context>
-                </context-group>
-            </trans-unit>
+                
+            <context-group purpose="location"><context context-type="sourcefile">app/home/home.component.html</context><context context-type="linenumber">98</context></context-group></trans-unit>
             <trans-unit id="ngbCarouselPrev" datatype="html">
                 <source>Précédent</source>
                 <target state="new">Previous</target>
 
                 <note priority="1" from="description">Carousel previous</note>
-                <context-group purpose="location">
-                    <context context-type="sourcefile">app/home/home.component.html</context>
-                    <context context-type="linenumber">123</context>
-                </context-group>
-            </trans-unit>
+                
+            <context-group purpose="location"><context context-type="sourcefile">app/home/home.component.html</context><context context-type="linenumber">123</context></context-group></trans-unit>
 
             <trans-unit id="ngbCarouselNext" datatype="html">
                 <source>Prochain</source>
                 <target state="new">Next</target>
 
                 <note priority="1" from="description">Carousel next</note>
-                <context-group purpose="location">
-                    <context context-type="sourcefile">app/home/home.component.html</context>
-                    <context context-type="linenumber">127</context>
-                </context-group>
-            </trans-unit>
+                
+            <context-group purpose="location"><context context-type="sourcefile">app/home/home.component.html</context><context context-type="linenumber">127</context></context-group></trans-unit><trans-unit id="pageNotFoundTitle" datatype="html">
+        <source>Page non trouvé</source><target state="new">Page not found</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/page-not-found/page-not-found.component.html</context>
+          <context context-type="linenumber">6</context>
+        </context-group>
+        <note priority="1" from="description">Title for 404 error page</note>
+      </trans-unit><trans-unit id="error404Text" datatype="html">
+        <source>Erreur 404</source><target state="new">Error 404</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/page-not-found/page-not-found.component.html</context>
+          <context context-type="linenumber">13</context>
+        </context-group>
+        <note priority="1" from="description">Text for 404 error</note>
+      </trans-unit><trans-unit id="homeLink" datatype="html">
+        <source>Accueil</source><target state="new">Home</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">custom/footer/footer.html</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+        <note priority="1" from="description">Home link</note>
+      </trans-unit><trans-unit id="aboutLink" datatype="html">
+        <source>A propos</source><target state="new">About</target>
+        
+        <note priority="1" from="description">About link</note>
+      <context-group purpose="location"><context context-type="sourcefile">custom/footer/footer.html</context><context context-type="linenumber">6</context></context-group></trans-unit>
             <trans-unit id="logout" datatype="html">
                 <source>Se déconnecter</source>
                 <target state="new">Sign out</target>
@@ -975,7 +1671,52 @@
                     <context context-type="sourcefile">app/core/topbar/topbar.component.html</context>
                     <context context-type="linenumber">54</context>
                 </context-group>
-            </trans-unit>
+            </trans-unit><trans-unit id="myObservationsButton" datatype="html">
+        <source>
+                            Mes observations
+                            <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong>"/><x id="INTERPOLATION" equiv-text="{{
+                                stats?.platform_attendance
+                                }}"/><x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong>"/>
+                        </source><target state="new">
+                            My observations
+                            <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong>"/><x id="INTERPOLATION" equiv-text="{{
+                                stats?.platform_attendance
+                                }}"/><x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong>"/>
+                        </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context>
+          <context context-type="linenumber">13</context>
+        </context-group>
+        <note priority="1" from="description">Observations button</note>
+      </trans-unit><trans-unit id="mySitesButton" datatype="html">
+        <source>
+                            Mes sites
+                            <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong>"/><x id="INTERPOLATION" equiv-text="{{
+                                mysites?.features.length
+                                }}"/><x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong>"/>
+                        </source><target state="new">
+                            My sites
+                            <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong>"/><x id="INTERPOLATION" equiv-text="{{
+                                mysites?.features.length
+                                }}"/><x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong>"/>
+                        </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context>
+          <context context-type="linenumber">22</context>
+        </context-group>
+        <note priority="1" from="description">Sites button</note>
+      </trans-unit><trans-unit id="username" datatype="html">
+        <source>
+                        <x id="INTERPOLATION" equiv-text="{{ username }}"/> <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i>"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i>"/>
+                    </source><target state="new">
+                        <x id="INTERPOLATION" equiv-text="{{ username }}"/> <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i>"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i>"/>
+                    </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context>
+          <context context-type="linenumber">34</context>
+        </context-group>
+        <note priority="1" from="description">Username</note>
+      </trans-unit>
             <trans-unit id="myBadges" datatype="html">
                 <source>Mes badges</source>
                 <target state="new">My rewards</target>
@@ -993,7 +1734,21 @@
 
                 <note priority="1" from="description">General Awards</note>
 
-            <context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">42</context></context-group></trans-unit>
+            <context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">42</context></context-group></trans-unit><trans-unit id="programAwards" datatype="html">
+        <source>Récompenses par programmes</source><target state="new">Program awards</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context>
+          <context context-type="linenumber">54</context>
+        </context-group>
+        <note priority="1" from="description">Program Awards</note>
+      </trans-unit><trans-unit id="recognitionAwards" datatype="html">
+        <source>Récompenses d'identification d'espèces</source><target state="new">Species identification awards</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context>
+          <context context-type="linenumber">64</context>
+        </context-group>
+        <note priority="1" from="description">Recognition Awards</note>
+      </trans-unit>
             <trans-unit id="exportPersonnalDataBtn" datatype="html">
                 <source>Exporter mes données
                         personnelles</source>
@@ -1024,7 +1779,14 @@
 
                 <note priority="1" from="description">Delete Account</note>
 
-            <context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">95</context></context-group></trans-unit>
+            <context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">95</context></context-group></trans-unit><trans-unit id="backSite" datatype="html">
+        <source>Retour au site</source><target state="new">Back to the site</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context>
+          <context context-type="linenumber">102</context>
+        </context-group>
+        <note priority="1" from="description">back</note>
+      </trans-unit>
             <trans-unit id="updatePersonnalData" datatype="html">
                 <source>
                     Mettre à jour vos données personnelles
@@ -1035,7 +1797,7 @@
 
                 <note priority="1" from="description">Update personnal data</note>
 
-            <context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">112</context></context-group></trans-unit>
+            <context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">111</context></context-group></trans-unit>
             <trans-unit id="yourUsernameInputPlaceholder" datatype="html">
                 <source>Entrez votre nom d'utilisateur</source>
                 <target state="new">Enter your username</target>
@@ -1044,21 +1806,21 @@
                                     your username
                                     placeholder</note>
 
-            <context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">146</context></context-group></trans-unit>
+            <context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">145</context></context-group></trans-unit>
             <trans-unit id="yourEmailInputLabel" datatype="html">
                 <source>Votre email *</source>
                 <target state="new">Your email *</target>
 
                 <note priority="1" from="description">your email label</note>
 
-            <context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">152</context></context-group></trans-unit>
+            <context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">151</context></context-group></trans-unit>
             <trans-unit id="yourFirstnameInputLabel" datatype="html">
                 <source>Votre prénom *</source>
-                <target state="new">Votre first name *</target>
+                <target state="new">Your first name *</target>
 
                 <note priority="1" from="description">your first name</note>
 
-            <context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">168</context></context-group></trans-unit>
+            <context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">167</context></context-group></trans-unit>
             <trans-unit id="yourFirstnameInputPlaceholder" datatype="html">
                 <source>Entrez votre prénom</source>
                 <target state="new">Enter your first name</target>
@@ -1067,14 +1829,14 @@
                                 your first name
                                 placeholder</note>
 
-            <context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">172</context></context-group></trans-unit>
+            <context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">171</context></context-group></trans-unit>
             <trans-unit id="yourSurnameInputLabel" datatype="html">
                 <source>Votre nom *</source>
                 <target state="new">Your last name *</target>
 
                 <note priority="1" from="description">your surname label</note>
 
-            <context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">177</context></context-group></trans-unit>
+            <context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">176</context></context-group></trans-unit>
             <trans-unit id="yourSurnameInputPlaceholder" datatype="html">
                 <source>Entrez votre nom</source>
                 <target state="new">Enter your last name</target>
@@ -1083,7 +1845,7 @@
                                 your surname
                                 placeholder</note>
 
-            <context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">181</context></context-group></trans-unit>
+            <context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">180</context></context-group></trans-unit>
             <trans-unit id="errorDifferentPasswords" datatype="html">
                 <source>
                     Les mots de passe diffèrent.
@@ -1094,7 +1856,7 @@
 
                 <note priority="1" from="description">error different passwords</note>
 
-            <context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">189</context></context-group></trans-unit>
+            <context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">188</context></context-group></trans-unit>
             <trans-unit id="yourPasswordLabel" datatype="html">
                 <source>Votre nouveau mot de
                             passe</source>
@@ -1102,7 +1864,7 @@
 
                 <note priority="1" from="description">your password label</note>
 
-            <context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">195</context></context-group></trans-unit>
+            <context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">194</context></context-group></trans-unit>
             <trans-unit id="yourPasswordPlaceholder" datatype="html">
                 <source>Votre nouveau mot de passe</source>
                 <target state="new">Your new password</target>
@@ -1111,7 +1873,7 @@
                                 your password
                                 placeholder</note>
 
-            <context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">200</context></context-group></trans-unit>
+            <context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">199</context></context-group></trans-unit>
             <trans-unit id="yourConfirmPasswordLabel" datatype="html">
                 <source>Confirmez votre nouveau mot de passe</source>
                 <target state="new">Confirm your new password</target>
@@ -1120,7 +1882,7 @@
                                 your password confirm
                                 label</note>
 
-            <context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">208</context></context-group></trans-unit>
+            <context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">207</context></context-group></trans-unit>
             <trans-unit id="yourConfirmPasswordPlaceholder" datatype="html">
                 <source>Votre nouveau mot de passe</source>
                 <target state="new">Your new password</target>
@@ -1129,7 +1891,18 @@
                                 your password confirm
                                 placeholder</note>
 
-            <context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">212</context></context-group></trans-unit>
+            <context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">211</context></context-group></trans-unit><trans-unit id="passwordMismatch" datatype="html">
+        <source>
+                            * Le mot de passe n'est pas identique.
+                        </source><target state="new">
+                            * The password does not match.
+                        </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context>
+          <context context-type="linenumber">217</context>
+        </context-group>
+        <note priority="1" from="description">Password mismatch</note>
+      </trans-unit>
             <trans-unit id="updatePersonnalDataBtn" datatype="html">
                 <source>
                     Mettre à jour
@@ -1140,7 +1913,130 @@
 
                 <note priority="1" from="description">update personnal data btn</note>
 
-            <context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">226</context></context-group></trans-unit>
+            <context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">225</context></context-group></trans-unit><trans-unit id="deleteObservationConfirmation" datatype="html">
+        <source>
+        Êtes-vous sûr de vouloir supprimer cette observation ?
+        <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/>"/>
+        Sa suppression sera définitive
+    </source><target state="new">
+        Are you sure you want to delete this observation?
+        <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/>"/>
+        The deletion will be permanent
+    </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context>
+          <context context-type="linenumber">236</context>
+        </context-group>
+        <note priority="1" from="description">Delete observation confirmation</note>
+      </trans-unit><trans-unit id="deleteSiteConfirmation" datatype="html">
+        <source>
+        Êtes-vous sûr de vouloir supprimer ce site et toutes les informations
+        qui y sont rattachées ?
+        <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/>"/>
+        La suppression sera définitive
+    </source><target state="new">
+        Are you sure you want to delete this site and all related information?
+        <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/>"/>
+        The deletion will be permanent
+    </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context>
+          <context context-type="linenumber">255</context>
+        </context-group>
+        <note priority="1" from="description">Delete site confirmation</note>
+      </trans-unit><trans-unit id="proposedIdentification" datatype="html">
+        <source>
+            Identification proposée : 
+            <x id="START_TAG_NG-CONTAINER" ctype="x-ng-container" equiv-text="&lt;ng-container>"/><x id="INTERPOLATION" equiv-text="{{ obsToValidate.properties.nom_francais || obsToValidate.properties.taxref.nom_vern }}"/><x id="CLOSE_TAG_NG-CONTAINER" ctype="x-ng-container" equiv-text="&lt;/ng-container>"/>
+            <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span>"/>
+              (<x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i>"/><x id="INTERPOLATION_1" equiv-text="{{ obsToValidate.properties.taxref.lb_nom }}"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i>"/>)
+            <x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span>"/>
+          </source><target state="new">
+            Proposed identification: 
+            <x id="START_TAG_NG-CONTAINER" ctype="x-ng-container" equiv-text="&lt;ng-container>"/><x id="INTERPOLATION" equiv-text="{{ obsToValidate.properties.nom_francais || obsToValidate.properties.taxref.nom_vern }}"/><x id="CLOSE_TAG_NG-CONTAINER" ctype="x-ng-container" equiv-text="&lt;/ng-container>"/>
+            <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span>"/>
+              (<x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i>"/><x id="INTERPOLATION_1" equiv-text="{{ obsToValidate.properties.taxref.lb_nom }}"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i>"/>)
+            <x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span>"/>
+          </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/observations/validation/validation.component.html</context>
+          <context context-type="linenumber">30</context>
+        </context-group>
+        <note priority="1" from="description">Title for identification proposed</note>
+      </trans-unit><trans-unit id="speciesSearchOrValidation" datatype="html">
+        <source>{VAR_SELECT, select, isOn {Rechercher une espèce} isOff {Validez ou corrigez l'espèce} }</source><target state="new">{VAR_SELECT, select, isOn {Search for a species} isOff {Validate or correct the species} }</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/observations/validation/validation.component.html</context>
+          <context context-type="linenumber">39</context>
+        </context-group>
+        <note priority="1" from="description">Label for species search or validation</note>
+      </trans-unit><trans-unit id="notifyObserverLabel" datatype="html">
+        <source>
+                Avertir l'observateur
+            </source><target state="new">
+                Notify the observer
+            </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/observations/validation/validation.component.html</context>
+          <context context-type="linenumber">128</context>
+        </context-group>
+        <note priority="1" from="description">Label for notifying the observer</note>
+      </trans-unit><trans-unit id="observerNotificationDescription" datatype="html">
+        <source>L'observateur recevra un mail contenant des informations de validation,
+                correction ou d'invalidité de son observation.</source><target state="new">The observer will receive an email containing validation,
+                correction, or invalidity information about their observation.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/observations/validation/validation.component.html</context>
+          <context context-type="linenumber">131</context>
+        </context-group>
+        <note priority="1" from="description">Description for observer notification</note>
+      </trans-unit><trans-unit id="unvalidableObservationLabel" datatype="html">
+        <source>
+            Si l'observation est non validable en l'état :
+        </source><target state="new">
+            If the observation is not validatable as is:
+        </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/observations/validation/validation.component.html</context>
+          <context context-type="linenumber">136</context>
+        </context-group>
+        <note priority="1" from="description">Label for unvalidable observation</note>
+      </trans-unit><trans-unit id="requestObserverModification" datatype="html">
+        <source>Demander à l'observateur de modifier son observation ou a un autre
+                    validateur de la vérifier.</source><target state="new">Ask the observer to modify their observation or have another
+                    validator check it.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/observations/validation/validation.component.html</context>
+          <context context-type="linenumber">146</context>
+        </context-group>
+        <note priority="1" from="description">Request for observer modification or validator check</note>
+      </trans-unit><trans-unit id="obsActionBtn" datatype="html">
+        <source>
+            <x id="ICU" equiv-text="{ obsValidatable, select, true {...} false {...}}"/>
+        </source><target state="new">
+            <x id="ICU" equiv-text="{ obsValidatable, select, true {...} false {...}}"/>
+        </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/observations/validation/validation.component.html</context>
+          <context context-type="linenumber">154</context>
+        </context-group>
+        <note priority="1" from="description">Button for validating, correcting, or invalidating an observation</note>
+      </trans-unit><trans-unit id="a5cf87dd6048bc6d23f027b10d8a50f741000bc3" datatype="html">
+        <source>{VAR_SELECT_1, select, true {{VAR_SELECT, select, true {Corriger l'observation} false {Valider l'observation} }
+                    } false {Invalider l'observation} }</source><target state="new">{VAR_SELECT_1, select, true {{VAR_SELECT, select, true {Correct the observation} false {Validate the observation} }
+                    } false {Invalidate the observation} }</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/observations/validation/validation.component.html</context>
+          <context context-type="linenumber">155</context>
+        </context-group>
+      </trans-unit><trans-unit id="discoverINPN" datatype="html">
+        <source>Découvrir sur INPN</source><target state="new">Discover on INPN</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/synthesis/species/species.component.html</context>
+          <context context-type="linenumber">20</context>
+        </context-group>
+        <note priority="1" from="description">Link to INPN</note>
+      </trans-unit>
             <trans-unit id="redirectToHome" datatype="html">
                 <source>vous allez être redirigé automatiquement sur la page d'accueil</source>
                 <target state="new">you will be automatically redirected to the home page</target>

--- a/frontend/src/i18n/messages.fr.xlf
+++ b/frontend/src/i18n/messages.fr.xlf
@@ -195,7 +195,7 @@
 
 
         <note priority="1" from="description">Your pseudo</note>
-      <context-group purpose="location"><context context-type="sourcefile">app/auth/register/register.component.html</context><context context-type="linenumber">33</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">137</context></context-group></trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/auth/register/register.component.html</context><context context-type="linenumber">33</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">136</context></context-group></trans-unit>
       <trans-unit id="yourUsernameInputPlaceHolder" datatype="html">
         <source>Entrez votre pseudonyme</source><target state="final">Entrez votre pseudonyme</target>
 
@@ -211,7 +211,7 @@
 
 
         <note priority="1" from="description">Your email input placeholder label</note>
-      <context-group purpose="location"><context context-type="sourcefile">app/auth/register/register.component.html</context><context context-type="linenumber">54</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">160</context></context-group></trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/auth/register/register.component.html</context><context context-type="linenumber">54</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">159</context></context-group></trans-unit>
       <trans-unit id="yourFirstNameLabel" datatype="html">
         <source>Votre prénom</source><target state="final">Votre prénom</target>
 
@@ -266,7 +266,18 @@
         <source>Confirmez le mot de passe</source><target state="final">Confirmez le mot de passe</target>
 
         <note priority="1" from="description">Your confirm password input</note>
-      <context-group purpose="location"><context context-type="sourcefile">app/auth/register/register.component.html</context><context context-type="linenumber">105</context></context-group></trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/auth/register/register.component.html</context><context context-type="linenumber">105</context></context-group></trans-unit><trans-unit id="invalidPasswordError" datatype="html">
+        <source>
+                        S'il vous plait entrez un mot de passe valide.
+                    </source><target state="final">
+                        Please provide a valid city.
+                    </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/auth/register/register.component.html</context>
+          <context context-type="linenumber">107</context>
+        </context-group>
+        <note priority="1" from="description">Error message for invalid password</note>
+      </trans-unit>
       <trans-unit id="acceptUGC" datatype="html">
         <source>
                     Veuillez accepter les conditions d'utilisation.
@@ -275,7 +286,11 @@
                 </target>
 
         <note priority="1" from="description">Accept UGC</note>
-      <context-group purpose="location"><context context-type="sourcefile">app/auth/register/register.component.html</context><context context-type="linenumber">114</context></context-group></trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/auth/register/register.component.html</context><context context-type="linenumber">114</context></context-group></trans-unit><trans-unit id="iAcceptIntro" datatype="html">
+        <source>J'accepte les</source><target state="final">J'accepte les</target>
+        
+        <note priority="1" from="description">I Accept</note>
+      <context-group purpose="location"><context context-type="sourcefile">app/auth/register/register.component.html</context><context context-type="linenumber">119</context></context-group></trans-unit>
       <trans-unit id="conditionsOfUse" datatype="html">
         <source>conditions d'utilisation</source><target state="final">conditions d'utilisation</target>
 
@@ -289,7 +304,7 @@
         </target>
 
         <note priority="1" from="description">register link</note>
-      <context-group purpose="location"><context context-type="sourcefile">app/auth/register/register.component.html</context><context context-type="linenumber">132</context></context-group></trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/auth/register/register.component.html</context><context context-type="linenumber">133</context></context-group></trans-unit>
       <trans-unit id="closeModal" datatype="html">
         <source>
         Fermer
@@ -299,7 +314,7 @@
 
 
         <note priority="1" from="description">close modal</note>
-      <context-group purpose="location"><context context-type="sourcefile">app/auth/register/register.component.html</context><context context-type="linenumber">137</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/auth/login/login.component.html</context><context context-type="linenumber">163</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/programs/media-galery/media-galery.component.html</context><context context-type="linenumber">50</context></context-group></trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/auth/register/register.component.html</context><context context-type="linenumber">138</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/auth/login/login.component.html</context><context context-type="linenumber">163</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/programs/media-galery/media-galery.component.html</context><context context-type="linenumber">50</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/programs/base/detail/detail.component.html</context><context context-type="linenumber">172</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/programs/base/detail/detail.component.html</context><context context-type="linenumber">172</context></context-group></trans-unit>
       <trans-unit id="login" datatype="html">
         <source>Se connecter</source><target state="final">Se connecter</target>
 
@@ -364,6 +379,13 @@
           <context context-type="linenumber">3</context>
         </context-group>
         <note priority="1" from="description">Add new obs</note>
+      </trans-unit><trans-unit id="whyRegisterHeading" datatype="html">
+        <source>Pourquoi s'inscrire ?</source><target state="final">Pourquoi s'inscrire ?</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/observations/modalflow/steps/onboard/onboard.component.html</context>
+          <context context-type="linenumber">14</context>
+        </context-group>
+        <note priority="1" from="description">Heading for why to register</note>
       </trans-unit>
       <trans-unit id="registerAndContribute" datatype="html">
         <source>S'incrire <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/>"/>et contribuer au site</source><target state="final">S'incrire <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/>"/>et contribuer au site</target>
@@ -383,7 +405,36 @@
         Connectez-vous !</target>
 
         <note priority="1" from="description">Invite to login</note>
-      <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/modalflow/steps/onboard/onboard.component.html</context><context context-type="linenumber">36</context></context-group></trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/modalflow/steps/onboard/onboard.component.html</context><context context-type="linenumber">36</context></context-group></trans-unit><trans-unit id="speciesSearchSelectionLabel" datatype="html">
+        <source>{VAR_SELECT, select, isOn {Rechercher une espèce} isOff {Sélectionnez une espèce} }</source><target state="final">{VAR_SELECT, select, isOn {Rechercher une espèce} isOff {Sélectionnez une espèce} }</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/observations/form/form.component.html</context>
+          <context context-type="linenumber">26</context>
+        </context-group>
+        <note priority="1" from="description">Label for species search and selection</note>
+      </trans-unit><trans-unit id="chooseSpeciesOption" datatype="html">
+        <source>Choisissez une espèce</source><target state="final">Choisissez une espèce</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/observations/form/form.component.html</context>
+          <context context-type="linenumber">37</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/observations/validation/validation.component.html</context>
+          <context context-type="linenumber">49</context>
+        </context-group>
+        <note priority="1" from="description">Option to choose a species</note>
+      </trans-unit><trans-unit id="speciesNamePlaceholder" datatype="html">
+        <source>Nom latin ou vernaculaire ou cd_ref</source><target state="final">Nom latin ou vernaculaire ou cd_ref</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/observations/form/form.component.html</context>
+          <context context-type="linenumber">83</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/observations/validation/validation.component.html</context>
+          <context context-type="linenumber">95</context>
+        </context-group>
+        <note priority="1" from="description">Placeholder for species name input</note>
+      </trans-unit>
       <trans-unit id="additionalInfos" datatype="html">
         <source>
                 Informations complémentaires
@@ -392,50 +443,50 @@
             </target>
 
         <note priority="1" from="description">Additional information</note>
-      <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">91</context></context-group></trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">93</context></context-group></trans-unit>
       <trans-unit id="bservationDate" datatype="html">
         <source>Date de l'observation</source><target state="final">Date de l'observation</target>
 
         <note priority="1" from="description">observation date</note>
-      <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">97</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/programs/observations/validation/validation.component.html</context><context context-type="linenumber">99</context></context-group></trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">99</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/programs/observations/validation/validation.component.html</context><context context-type="linenumber">104</context></context-group></trans-unit>
       <trans-unit id="expectedDateFormat" datatype="html">
         <source>jj/mm/aaaa</source><target state="final">jj/mm/aaaa</target>
 
         <note priority="1" from="description">
                                 expected date format</note>
-      <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">99</context></context-group></trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">101</context></context-group></trans-unit>
       <trans-unit id="enumerationInputLabel" datatype="html">
         <source>Dénombrement</source><target state="final">Dénombrement</target>
 
         <note priority="1" from="description">Enumeration Label</note>
-      <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">104</context></context-group></trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">106</context></context-group></trans-unit>
       <trans-unit id="enumerationInputPlaceHolder" datatype="html">
         <source>Nombre</source><target state="final">Nombre</target>
 
         <note priority="1" from="description">
                             Enumeration Placeholder</note>
-      <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">106</context></context-group></trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">108</context></context-group></trans-unit>
       <trans-unit id="commentInputLabel" datatype="html">
         <source>Commentaire</source><target state="final">Commentaire</target>
 
         <note priority="1" from="description">Comment Input Label</note>
-      <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">117</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/programs/observations/validation/validation.component.html</context><context context-type="linenumber">113</context></context-group></trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">119</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/programs/observations/validation/validation.component.html</context><context context-type="linenumber">118</context></context-group></trans-unit>
       <trans-unit id="commentInputPlaceholder" datatype="html">
         <source>Votre commentaire</source><target state="final">Votre commentaire</target>
 
         <note priority="1" from="description">
                         Comment Input Placeholder</note>
-      <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">119</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/programs/observations/validation/validation.component.html</context><context context-type="linenumber">116</context></context-group></trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">121</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/programs/observations/validation/validation.component.html</context><context context-type="linenumber">121</context></context-group></trans-unit>
       <trans-unit id="existingPhotos" datatype="html">
         <source>Photos existantes (cocher pour supprimer)</source><target state="final">Photos existantes (cocher pour supprimer)</target>
 
         <note priority="1" from="description">Existing Photos</note>
-      <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">124</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/programs/sites/form/form.component.html</context><context context-type="linenumber">35</context></context-group></trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">126</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/programs/sites/form/form.component.html</context><context context-type="linenumber">35</context></context-group></trans-unit>
       <trans-unit id="addPhoto" datatype="html">
         <source>Ajouter une photo</source><target state="final">Ajouter une photo</target>
 
         <note priority="1" from="description">Add photo</note>
-      <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">132</context></context-group></trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">134</context></context-group></trans-unit>
       <trans-unit id="obsLocation" datatype="html">
         <source>
                 Où avez-vous observé cette espèce ?
@@ -444,7 +495,7 @@
             </target>
 
         <note priority="1" from="description">observation Location</note>
-      <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">140</context></context-group></trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">142</context></context-group></trans-unit>
       <trans-unit id="ZoomToPointInstruction" datatype="html">
         <source>
                         Veuillez zoomer pour localiser votre observation.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/>"/>
@@ -456,14 +507,14 @@
                             <x id="INTERPOLATION" equiv-text="{{ MAP_CONFIG.ZOOM_LEVEL_RELEVE }}"/>)<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span>"/>
                     </target>
 
-      <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">145</context></context-group></trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">147</context></context-group></trans-unit>
       <trans-unit id="zoomingInstruction" datatype="html">
         <source>Veuillez zoomer pour localiser votre observation.</source><target state="final">Veuillez zoomer pour localiser votre observation.</target>
 
 
         <note priority="1" from="description">
                         Zooming instruction</note>
-      <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">158</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/programs/sites/siteform/siteform.component.html</context><context context-type="linenumber">28</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/programs/observations/validation/validation.component.html</context><context context-type="linenumber">110</context></context-group></trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">160</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/programs/sites/siteform/siteform.component.html</context><context context-type="linenumber">33</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/programs/observations/validation/validation.component.html</context><context context-type="linenumber">115</context></context-group></trans-unit>
       <trans-unit id="clickOnMapInstruction" datatype="html">
         <source>Cliquez sur
                     la carte pour renseigner le lieu
@@ -474,21 +525,21 @@
                     votre observation</target>
 
         <note priority="1" from="description">click on map instruction</note>
-      <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">163</context></context-group></trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">165</context></context-group></trans-unit>
       <trans-unit id="contactEmailInputLabel" datatype="html">
         <source>E-mail de contact
                 </source><target state="final">E-mail de contact
                 </target>
 
         <note priority="1" from="description">Contact email input label</note>
-      <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">178</context></context-group></trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">180</context></context-group></trans-unit>
       <trans-unit id="contactEmailInputPlaceHolder" datatype="html">
         <source>E-Mail</source><target state="final">E-Mail</target>
 
         <note priority="1" from="description">
                         Contact email input
                         placeholder</note>
-      <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">182</context></context-group></trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">184</context></context-group></trans-unit>
       <trans-unit id="missingFieldsAlert" datatype="html">
         <source>
             Champs manquants
@@ -497,7 +548,7 @@
         </target>
 
         <note priority="1" from="description">Missing fields alert</note>
-      <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">189</context></context-group></trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/form/form.component.html</context><context context-type="linenumber">191</context></context-group></trans-unit>
       <trans-unit id="updateObs" datatype="html">
         <source>
         MODIFIER L'OBSERVATION
@@ -506,7 +557,14 @@
     </target>
 
         <note priority="1" from="description">Update obs</note>
-      <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/modalflow/steps/committed/committed.component.html</context><context context-type="linenumber">6</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/programs/observations/obs.component.html</context><context context-type="linenumber">74</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/programs/observations/obs.component.html</context><context context-type="linenumber">74</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/programs/observations/obs.component.html</context><context context-type="linenumber">74</context></context-group></trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/modalflow/steps/committed/committed.component.html</context><context context-type="linenumber">6</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/programs/observations/obs.component.html</context><context context-type="linenumber">72</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/programs/observations/obs.component.html</context><context context-type="linenumber">72</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/programs/observations/obs.component.html</context><context context-type="linenumber">72</context></context-group></trans-unit><trans-unit id="informationHeading" datatype="html">
+        <source>Information</source><target state="final">Information</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/observations/modalflow/steps/committed/committed.component.html</context>
+          <context context-type="linenumber">20</context>
+        </context-group>
+        <note priority="1" from="description">Heading for information section</note>
+      </trans-unit>
       <trans-unit id="validObsBtn" datatype="html">
         <source>
         Valider l'observation
@@ -515,7 +573,7 @@
     </target>
 
         <note priority="1" from="description">Valid obs btn</note>
-      <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/modalflow/steps/committed/committed.component.html</context><context context-type="linenumber">32</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/programs/observations/validation/validation.component.html</context><context context-type="linenumber">149</context></context-group></trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/modalflow/steps/committed/committed.component.html</context><context context-type="linenumber">32</context></context-group></trans-unit>
       <trans-unit id="updateObsBtn" datatype="html">
         <source>
         Modifier l'observation
@@ -533,7 +591,7 @@
     </target>
 
         <note priority="1" from="description">Cancel</note>
-      <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/modalflow/steps/committed/committed.component.html</context><context context-type="linenumber">40</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/programs/observations/validation/validation.component.html</context><context context-type="linenumber">153</context></context-group></trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/modalflow/steps/committed/committed.component.html</context><context context-type="linenumber">40</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/programs/base/detail/detail.component.html</context><context context-type="linenumber">193</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/programs/base/detail/detail.component.html</context><context context-type="linenumber">193</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">242</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">262</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/programs/observations/validation/validation.component.html</context><context context-type="linenumber">166</context></context-group></trans-unit>
       <trans-unit id="congrats" datatype="html">
         <source>Félicitations !</source><target state="final">Félicitations !</target>
 
@@ -548,7 +606,7 @@
     </target>
 
         <note priority="1" from="description">Congrats message</note>
-      <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/modalflow/steps/congrats/congrats.component.html</context><context context-type="linenumber">17</context></context-group></trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/modalflow/steps/congrats/congrats.component.html</context><context context-type="linenumber">17</context></context-group><context-group purpose="location"><context context-type="sourcefile">app/programs/sites/modalflow/steps/congrats/congrats.component.html</context><context context-type="linenumber">5</context></context-group></trans-unit>
       <trans-unit id="obsDateObserver" datatype="html">
         <source>Observé par <x id="INTERPOLATION" equiv-text="{{ username || 'Anonyme' }}"/> <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/>"/>
         le <x id="INTERPOLATION_1" equiv-text="{{ obs.date }}"/></source><target state="final">Observé par <x id="INTERPOLATION" equiv-text="{{ username || 'Anonyme' }}"/> <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/>"/>
@@ -570,11 +628,48 @@
             ce badge } other {Vous venez d'obtenir ces badges } }</source><target state="final">{VAR_PLURAL, plural, =1 {Vous venez d'obtenir
             ce badge } other {Vous venez d'obtenir ces badges } }</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/modalflow/steps/reward/reward.component.html</context><context context-type="linenumber">8</context></context-group></trans-unit><trans-unit id="NoMediasInfo" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/modalflow/steps/reward/reward.component.html</context><context context-type="linenumber">8</context></context-group></trans-unit><trans-unit id="zoomWarning" datatype="html">
+        <source>Veuillez zoomer pour localiser votre observation.</source><target state="final">Veuillez zoomer pour localiser votre observation.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/observations/map/map.component.html</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+        <note priority="1" from="description">Warning message for zoom on observation map</note>
+      </trans-unit><trans-unit id="observationDetailsLink" datatype="html">
+        <source><x id="START_LINK" ctype="x-a" equiv-text="&lt;a>"/><x id="INTERPOLATION" equiv-text="{{ m.name }}"/> le <x id="INTERPOLATION_1" equiv-text="{{ m.date | date: 'longDate' }}"/><x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/> par @<x id="INTERPOLATION_2" equiv-text="{{
+                    m.observer
+                    }}"/>
+                </source><target state="final"><x id="START_LINK" ctype="x-a" equiv-text="&lt;a>"/><x id="INTERPOLATION" equiv-text="{{ m.name }}"/> le <x id="INTERPOLATION_1" equiv-text="{{ m.date | date: 'longDate' }}"/><x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/> par @<x id="INTERPOLATION_2" equiv-text="{{
+                    m.observer
+                    }}"/>
+                </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/media-galery/media-galery.component.html</context>
+          <context context-type="linenumber">7</context>
+        </context-group>
+        <note priority="1" from="description">Link text for observation details</note>
+      </trans-unit><trans-unit id="NoMediasInfo" datatype="html">
         <source>Aucune photo</source><target state="final">Aucune photo</target>
 
         <note priority="1" from="description">No medias</note>
-      <context-group purpose="location"><context context-type="sourcefile">app/programs/media-galery/media-galery.component.html</context><context context-type="linenumber">18</context></context-group></trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/programs/media-galery/media-galery.component.html</context><context context-type="linenumber">18</context></context-group></trans-unit><trans-unit id="clickedPhotoModalTitle" datatype="html">
+        <source>
+                    <x id="INTERPOLATION" equiv-text="{{ clickedPhoto.name }}"/> le
+                    <x id="INTERPOLATION_1" equiv-text="{{ clickedPhoto.date | date: 'longDate' }}"/> par @<x id="INTERPOLATION_2" equiv-text="{{
+                    clickedPhoto.observer
+                    }}"/>
+                </source><target state="final">
+                    <x id="INTERPOLATION" equiv-text="{{ clickedPhoto.name }}"/> le
+                    <x id="INTERPOLATION_1" equiv-text="{{ clickedPhoto.date | date: 'longDate' }}"/> par @<x id="INTERPOLATION_2" equiv-text="{{
+                    clickedPhoto.observer
+                    }}"/>
+                </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/media-galery/media-galery.component.html</context>
+          <context context-type="linenumber">28</context>
+        </context-group>
+        <note priority="1" from="description">Modal title for clicked photo</note>
+      </trans-unit>
       <trans-unit id="allSpeciesSelectOption" datatype="html">
         <source>Toutes espèces</source><target state="final">Toutes espèces</target>
 
@@ -603,12 +698,608 @@
                     </target>
 
         <note priority="1" from="description">My obs</note>
-      <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/list/list.component.html</context><context context-type="linenumber">43</context></context-group></trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/programs/observations/list/list.component.html</context><context context-type="linenumber">43</context></context-group></trans-unit><trans-unit id="observationWithPhotoTooltip" datatype="html">
+        <source>Observation avec photo</source><target state="final">Observation avec photo</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/observations/list/list.component.html</context>
+          <context context-type="linenumber">70</context>
+        </context-group>
+        <note priority="1" from="description">Tooltip for observation with photo</note>
+      </trans-unit><trans-unit id="nonValidatedObservationTooltip" datatype="html">
+        <source>Observation non validée<x id="INTERPOLATION" equiv-text="{{o.properties.observer?.username == username ? ' - Validation par un tiers requise' : ''}}"/></source><target state="final">Observation non validée<x id="INTERPOLATION" equiv-text="{{o.properties.observer?.username == username ? ' - Validation par un tiers requise' : ''}}"/></target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/observations/list/list.component.html</context>
+          <context context-type="linenumber">104</context>
+        </context-group>
+        <note priority="1" from="description">Tooltip for non-validated observation</note>
+      </trans-unit><trans-unit id="invalidObservationTooltip" datatype="html">
+        <source>Observation invalide<x id="INTERPOLATION" equiv-text="{{o.properties.observer?.username == username ? ' - Validation par un tiers requise' : ''}}"/></source><target state="final">Observation invalide<x id="INTERPOLATION" equiv-text="{{o.properties.observer?.username == username ? ' - Validation par un tiers requise' : ''}}"/></target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/observations/list/list.component.html</context>
+          <context context-type="linenumber">109</context>
+        </context-group>
+        <note priority="1" from="description">Tooltip for invalid observation</note>
+      </trans-unit><trans-unit id="nonValidatableObservationTooltip" datatype="html">
+        <source>Observation non validable<x id="INTERPOLATION" equiv-text="{{o.properties.observer?.username == username ? ' - Validation par un tiers requise' : ''}}"/></source><target state="final">Observation non validable<x id="INTERPOLATION" equiv-text="{{o.properties.observer?.username == username ? ' - Validation par un tiers requise' : ''}}"/></target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/observations/list/list.component.html</context>
+          <context context-type="linenumber">114</context>
+        </context-group>
+        <note priority="1" from="description">Tooltip for non-validatable observation</note>
+      </trans-unit><trans-unit id="validatedObservationTooltip" datatype="html">
+        <source>Observation approuvée</source><target state="final">Observation approuvée</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/observations/list/list.component.html</context>
+          <context context-type="linenumber">119</context>
+        </context-group>
+        <note priority="1" from="description">Tooltip for validated observation</note>
+      </trans-unit><trans-unit id="editButtonTooltip" datatype="html">
+        <source>Editer</source><target state="final">Editer</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/observations/list/list.component.html</context>
+          <context context-type="linenumber">146</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/sites/list/list.component.html</context>
+          <context context-type="linenumber">24</context>
+        </context-group>
+        <note priority="1" from="description">Tooltip for edit button</note>
+      </trans-unit><trans-unit id="deleteButtonTooltip" datatype="html">
+        <source>Supprimer</source><target state="final">Supprimer</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/observations/list/list.component.html</context>
+          <context context-type="linenumber">150</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/sites/list/list.component.html</context>
+          <context context-type="linenumber">31</context>
+        </context-group>
+        <note priority="1" from="description">Tooltip for delete button</note>
+      </trans-unit><trans-unit id="datePrefix" datatype="html">
+        <source>le</source><target state="final">le</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/observations/list/list.component.html</context>
+          <context context-type="linenumber">157</context>
+        </context-group>
+        <note priority="1" from="description">Date prefix</note>
+      </trans-unit><trans-unit id="locationPrefix" datatype="html">
+        <source>à</source><target state="final">à</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/observations/list/list.component.html</context>
+          <context context-type="linenumber">160</context>
+        </context-group>
+        <note priority="1" from="description">Location prefix</note>
+      </trans-unit><trans-unit id="viewObservationDetailsTooltip" datatype="html">
+        <source>Voir les détails de cette observation</source><target state="final">Voir les détails de cette observation</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/observations/list/list.component.html</context>
+          <context context-type="linenumber">171</context>
+        </context-group>
+        <note priority="1" from="description">Tooltip for viewing observation details</note>
+      </trans-unit><trans-unit id="addButtonText" datatype="html">
+        <source>Ajouter</source><target state="final">Ajouter</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/observations/obs.component.html</context>
+          <context context-type="linenumber">47</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/sites/sites.component.html</context>
+          <context context-type="linenumber">75</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/sites/sites.component.html</context>
+          <context context-type="linenumber">82</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/observations/obs.component.html</context>
+          <context context-type="linenumber">47</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/observations/obs.component.html</context>
+          <context context-type="linenumber">47</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/sites/sites.component.html</context>
+          <context context-type="linenumber">75</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/sites/sites.component.html</context>
+          <context context-type="linenumber">82</context>
+        </context-group>
+        <note priority="1" from="description">Add button text</note>
+      </trans-unit><trans-unit id="addObservationTooltip" datatype="html">
+        <source>Ajouter une observation</source><target state="final">Ajouter une observation</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/observations/obs.component.html</context>
+          <context context-type="linenumber">45</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/observations/obs.component.html</context>
+          <context context-type="linenumber">45</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/observations/obs.component.html</context>
+          <context context-type="linenumber">45</context>
+        </context-group>
+        <note priority="1" from="description">Ajouter une observation</note>
+      </trans-unit><trans-unit id="informations" datatype="html">
+        <source>Informations</source><target state="final">Informations</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/sites/siteform/siteform.component.html</context>
+          <context context-type="linenumber">5</context>
+        </context-group>
+        <note priority="1" from="description">Informations</note>
+      </trans-unit><trans-unit id="siteTypeLabel" datatype="html">
+        <source>Type de site</source><target state="final">Type de site</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/sites/siteform/siteform.component.html</context>
+          <context context-type="linenumber">8</context>
+        </context-group>
+        <note priority="1" from="description">Libellé pour le champ Type de site</note>
+      </trans-unit><trans-unit id="siteNameLabel" datatype="html">
+        <source>Nom du site</source><target state="final">Nom du site</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/sites/siteform/siteform.component.html</context>
+          <context context-type="linenumber">25</context>
+        </context-group>
+        <note priority="1" from="description">Libellé pour le champ Nom du site</note>
+      </trans-unit><trans-unit id="locationSiteQuestion" datatype="html">
+        <source>Où est-il situé ?</source><target state="final">Où est-il situé ?</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/sites/siteform/siteform.component.html</context>
+          <context context-type="linenumber">30</context>
+        </context-group>
+        <note priority="1" from="description">Question localisation site</note>
+      </trans-unit>
       <trans-unit id="zoomingWarning" datatype="html">
         <source>Veuillez zoomer pour localiser votre observation.</source><target state="final">Veuillez zoomer pour localiser votre observation.</target>
 
         <note priority="1" from="description">Zooming warning</note>
-      <context-group purpose="location"><context context-type="sourcefile">app/programs/sites/siteform/siteform.component.html</context><context context-type="linenumber">45</context></context-group></trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/programs/sites/siteform/siteform.component.html</context><context context-type="linenumber">50</context></context-group></trans-unit><trans-unit id="addSiteTitle" datatype="html">
+        <source>AJOUTER UN SITE</source><target state="final">AJOUTER UN SITE</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/sites/modalflow/steps/site/site_step.component.html</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+        <note priority="1" from="description">Title for add site</note>
+      </trans-unit><trans-unit id="validSiteButton" datatype="html">
+        <source>
+        Valider le site
+    </source><target state="final">
+        Valider le site
+    </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/sites/modalflow/steps/site/site_step.component.html</context>
+          <context context-type="linenumber">29</context>
+        </context-group>
+        <note priority="1" from="description">button valid site</note>
+      </trans-unit><trans-unit id="stepTitle" datatype="html">
+        <source>
+            Etape <x id="INTERPOLATION" equiv-text="{{ currentStep }}"/>/<x id="INTERPOLATION_1" equiv-text="{{ totalSteps() }}"/> :
+            <x id="INTERPOLATION_2" equiv-text="{{ jsonSchema.steps[currentStep - 1].title }}"/>
+        </source><target state="final">
+            Etape <x id="INTERPOLATION" equiv-text="{{ currentStep }}"/>/<x id="INTERPOLATION_1" equiv-text="{{ totalSteps() }}"/> :
+            <x id="INTERPOLATION_2" equiv-text="{{ jsonSchema.steps[currentStep - 1].title }}"/>
+        </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/sites/form/form.component.html</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+        <note priority="1" from="description">Step Title</note>
+      </trans-unit><trans-unit id="visitDate" datatype="html">
+        <source>Date de la visite</source><target state="final">Date de la visite</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/sites/form/form.component.html</context>
+          <context context-type="linenumber">13</context>
+        </context-group>
+        <note priority="1" from="description">Visit Date</note>
+      </trans-unit><trans-unit id="dateRequired" datatype="html">
+        <source>
+                            La date est obligatoire
+                        </source><target state="final">
+                            La date est obligatoire
+                        </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/sites/form/form.component.html</context>
+          <context context-type="linenumber">17</context>
+        </context-group>
+        <note priority="1" from="description">Date Required</note>
+      </trans-unit><trans-unit id="futureDateError" datatype="html">
+        <source>
+                            La date doit être antérieure à la date du jour
+                        </source><target state="final">
+                            La date doit être antérieure à la date du jour
+                        </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/sites/form/form.component.html</context>
+          <context context-type="linenumber">24</context>
+        </context-group>
+        <note priority="1" from="description">Message d'erreur pour une date future</note>
+      </trans-unit><trans-unit id="invalidDateError" datatype="html">
+        <source>
+                            Date invalide
+                        </source><target state="final">
+                            Date invalide
+                        </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/sites/form/form.component.html</context>
+          <context context-type="linenumber">27</context>
+        </context-group>
+        <note priority="1" from="description">Message d'erreur pour une date invalide</note>
+      </trans-unit><trans-unit id="addSiteVisitReportTitle" datatype="html">
+        <source>AJOUTER UN RAPPORT DE VISITE</source><target state="final">AJOUTER UN RAPPORT DE VISITE</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/sites/modalflow/steps/visit/visit_step.component.html</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+        <note priority="1" from="description">Modal title for adding a site visit report</note>
+      </trans-unit><trans-unit id="previousStep" datatype="html">
+        <source>
+        Etape précédente
+    </source><target state="final">
+        Etape précédente
+    </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/sites/modalflow/steps/visit/visit_step.component.html</context>
+          <context context-type="linenumber">28</context>
+        </context-group>
+        <note priority="1" from="description">Previous Step</note>
+      </trans-unit><trans-unit id="nextStep" datatype="html">
+        <source>
+        Etape suivante
+    </source><target state="final">
+        Etape suivante
+    </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/sites/modalflow/steps/visit/visit_step.component.html</context>
+          <context context-type="linenumber">37</context>
+        </context-group>
+        <note priority="1" from="description">Next Step</note>
+      </trans-unit><trans-unit id="validVisitButton" datatype="html">
+        <source>
+        Valider la visite
+    </source><target state="final">
+        Valider la visite
+    </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/sites/modalflow/steps/visit/visit_step.component.html</context>
+          <context context-type="linenumber">47</context>
+        </context-group>
+        <note priority="1" from="description">button valid visit</note>
+      </trans-unit><trans-unit id="congratsTitle" datatype="html">
+        <source>Félicitations !</source><target state="final">Félicitations !</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/sites/modalflow/steps/congrats/congrats.component.html</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+        <note priority="1" from="description">Félicitations</note>
+      </trans-unit><trans-unit id="mySitesTitle" datatype="html">
+        <source>Mes Sites </source><target state="final">Mes Sites </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/sites/list/list.component.html</context>
+          <context context-type="linenumber">6</context>
+        </context-group>
+        <note priority="1" from="description">Titre pour Mes Sites</note>
+      </trans-unit><trans-unit id="addedMessage" datatype="html">
+        <source>
+                            <x id="START_TAG_NG-CONTAINER" ctype="x-ng-container" equiv-text="&lt;ng-container>"/><x id="INTERPOLATION" equiv-text="{{ o.properties.site_type.type | titlecase }}"/><x id="CLOSE_TAG_NG-CONTAINER" ctype="x-ng-container" equiv-text="&lt;/ng-container>"/> ajouté(e) par <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span>"/><x id="INTERPOLATION_1" equiv-text="{{ o.properties.obs_txt }}"/><x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span>"/>
+                        </source><target state="final">
+                            <x id="START_TAG_NG-CONTAINER" ctype="x-ng-container" equiv-text="&lt;ng-container>"/><x id="INTERPOLATION" equiv-text="{{ o.properties.site_type.type | titlecase }}"/><x id="CLOSE_TAG_NG-CONTAINER" ctype="x-ng-container" equiv-text="&lt;/ng-container>"/> ajouté(e) par <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span>"/><x id="INTERPOLATION_1" equiv-text="{{ o.properties.obs_txt }}"/><x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span>"/>
+                        </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/sites/list/list.component.html</context>
+          <context context-type="linenumber">41</context>
+        </context-group>
+        <note priority="1" from="description">Message d'ajout</note>
+      </trans-unit><trans-unit id="dateDeterminer" datatype="html">
+        <source>le</source><target state="final">le</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/sites/list/list.component.html</context>
+          <context context-type="linenumber">46</context>
+        </context-group>
+        <note priority="1" from="description">Déterminant pour une date</note>
+      </trans-unit><trans-unit id="addSiteButton" datatype="html">
+        <source>Ajouter</source><target state="final">Ajouter</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/sites/sites.component.html</context>
+          <context context-type="linenumber">45</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/sites/sites.component.html</context>
+          <context context-type="linenumber">45</context>
+        </context-group>
+        <note priority="1" from="description">Add site button text</note>
+      </trans-unit><trans-unit id="addSiteTooltip" datatype="html">
+        <source>Ajouter un site</source><target state="final">Ajouter un site</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/sites/sites.component.html</context>
+          <context context-type="linenumber">44</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/sites/sites.component.html</context>
+          <context context-type="linenumber">44</context>
+        </context-group>
+        <note priority="1" from="description">Tooltip for adding a site</note>
+      </trans-unit><trans-unit id="backToProgramLink" datatype="html">
+        <source>
+            <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i>"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i>"/>
+            Retour au programme</source><target state="final">
+            <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i>"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i>"/>
+            Retour au programme</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+        <note priority="1" from="description">Link to go back to the program</note>
+      </trans-unit><trans-unit id="addedDateObserverText" datatype="html">
+        <source>Ajoutée le
+                    <x id="INTERPOLATION" equiv-text="{{ (module === 'sites' ? site?.properties.timestamp_create.substring(0, 10) :
+                    obs?.properties.timestamp_create.substring(0, 10))
+                    | date: 'longDate'
+                    }}"/>
+                    par <x id="INTERPOLATION_1" equiv-text="{{ module === 'sites' ? site?.properties.obs_txt: obs?.properties.obs_txt }}"/></source><target state="final">Ajoutée le
+                    <x id="INTERPOLATION" equiv-text="{{ (module === 'sites' ? site?.properties.timestamp_create.substring(0, 10) :
+                    obs?.properties.timestamp_create.substring(0, 10))
+                    | date: 'longDate'
+                    }}"/>
+                    par <x id="INTERPOLATION_1" equiv-text="{{ module === 'sites' ? site?.properties.obs_txt: obs?.properties.obs_txt }}"/></target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">19</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">19</context>
+        </context-group>
+        <note priority="1" from="description">Text for added date and observer</note>
+      </trans-unit><trans-unit id="singleSiteVisitText" datatype="html">
+        <source>
+                            Visite du
+                            <x id="INTERPOLATION" equiv-text="{{
+                            site?.properties.visits[0].date
+                            | date: 'longDate'
+                            }}"/>
+                        </source><target state="final">
+                            Visite du
+                            <x id="INTERPOLATION" equiv-text="{{
+                            site?.properties.visits[0].date
+                            | date: 'longDate'
+                            }}"/>
+                        </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">40</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">40</context>
+        </context-group>
+        <note priority="1" from="description">Text for a single site visit date</note>
+      </trans-unit><trans-unit id="noVisitsMessage" datatype="html">
+        <source>Aucune visite enregistrée :(</source><target state="final">Aucune visite enregistrée :(</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">54</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">54</context>
+        </context-group>
+        <note priority="1" from="description">No visits recorded message</note>
+      </trans-unit><trans-unit id="addSiteVisitReportButton" datatype="html">
+        <source>Ajouter un rapport
+                    de visite</source><target state="final">Ajouter un rapport
+                    de visite</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">58</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">58</context>
+        </context-group>
+        <note priority="1" from="description">Button to add a site visit report</note>
+      </trans-unit><trans-unit id="observationCardTitle" datatype="html">
+        <source>Observation #<x id="INTERPOLATION" equiv-text="{{ obs_id }}"/></source><target state="final">Observation #<x id="INTERPOLATION" equiv-text="{{ obs_id }}"/></target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">65</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">65</context>
+        </context-group>
+        <note priority="1" from="description">Observation card title with ID</note>
+      </trans-unit><trans-unit id="observerLabel" datatype="html">
+        <source>Observateur :</source><target state="final">Observateur :</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">67</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">67</context>
+        </context-group>
+        <note priority="1" from="description">Observer label</note>
+      </trans-unit><trans-unit id="dateLabel" datatype="html">
+        <source>Date :</source><target state="final">Date :</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">68</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">68</context>
+        </context-group>
+        <note priority="1" from="description">Date label</note>
+      </trans-unit><trans-unit id="municipalityLabel" datatype="html">
+        <source>Commune :</source><target state="final">Commune :</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">70</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">70</context>
+        </context-group>
+        <note priority="1" from="description">Municipality label</note>
+      </trans-unit><trans-unit id="countLabel" datatype="html">
+        <source>Nombre :</source><target state="final">Nombre :</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">72</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">72</context>
+        </context-group>
+        <note priority="1" from="description">Count label</note>
+      </trans-unit><trans-unit id="photosSectionTitle" datatype="html">
+        <source>Photos</source><target state="final">Photos</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">84</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">84</context>
+        </context-group>
+        <note priority="1" from="description">Section title for photos</note>
+      </trans-unit><trans-unit id="photoDateAuthorLabel" datatype="html">
+        <source>Le <x id="INTERPOLATION" equiv-text="{{ photo.date | date: 'longDate' }}"/> par <x id="INTERPOLATION_1" equiv-text="{{ photo.author }}"/></source><target state="final">Le <x id="INTERPOLATION" equiv-text="{{ photo.date | date: 'longDate' }}"/> par <x id="INTERPOLATION_1" equiv-text="{{ photo.author }}"/></target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">93</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">93</context>
+        </context-group>
+        <note priority="1" from="description">Photo date and author label</note>
+      </trans-unit><trans-unit id="descriptionSectionTitle" datatype="html">
+        <source>Description</source><target state="final">Description</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">101</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">138</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">101</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">138</context>
+        </context-group>
+        <note priority="1" from="description">Section title for description</note>
+      </trans-unit><trans-unit id="siteVisitDateAuthor" datatype="html">
+        <source>
+                <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i>"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i>"/>
+                <x id="INTERPOLATION" equiv-text="{{ a.date | date: 'longDate' }}"/> par <x id="INTERPOLATION_1" equiv-text="{{ a.author }}"/>
+                <x id="START_ITALIC_TEXT_1" ctype="x-i" equiv-text="&lt;i>"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i>"/>
+                 
+                <x id="START_ITALIC_TEXT_2" ctype="x-i" equiv-text="&lt;i>"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i>"/>
+            </source><target state="final">
+                <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i>"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i>"/>
+                <x id="INTERPOLATION" equiv-text="{{ a.date | date: 'longDate' }}"/> par <x id="INTERPOLATION_1" equiv-text="{{ a.author }}"/>
+                <x id="START_ITALIC_TEXT_1" ctype="x-i" equiv-text="&lt;i>"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i>"/>
+                 
+                <x id="START_ITALIC_TEXT_2" ctype="x-i" equiv-text="&lt;i>"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i>"/>
+            </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">106</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">106</context>
+        </context-group>
+        <note priority="1" from="description">Date and author for site visit</note>
+      </trans-unit><trans-unit id="editSiteVisitTooltip" datatype="html">
+        <source>Editer</source><target state="final">Editer</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">109</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">109</context>
+        </context-group>
+        <note priority="1" from="description">Tooltip for edit site visit</note>
+      </trans-unit><trans-unit id="deleteSiteVisitTooltip" datatype="html">
+        <source>Supprimer</source><target state="final">Supprimer</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">113</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">113</context>
+        </context-group>
+        <note priority="1" from="description">Tooltip for delete site visit</note>
+      </trans-unit><trans-unit id="noDataMessage" datatype="html">
+        <source>Aucune donnée</source><target state="final">Aucune donnée</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">128</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">128</context>
+        </context-group>
+        <note priority="1" from="description">No data available message</note>
+      </trans-unit><trans-unit id="deleteSiteVisitConfirmation" datatype="html">
+        <source>
+        Êtes-vous sûr de vouloir supprimer cette visite et toutes les informations
+        qui y sont rattachées ?
+        <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/>"/>
+        La suppression sera définitive
+    </source><target state="final">
+        Êtes-vous sûr de vouloir supprimer cette visite et toutes les informations
+        qui y sont rattachées ?
+        <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/>"/>
+        La suppression sera définitive
+    </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">185</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">185</context>
+        </context-group>
+        <note priority="1" from="description">Confirmation message for deleting a site visit</note>
+      </trans-unit><trans-unit id="yes" datatype="html">
+        <source>
+            OUI
+        </source><target state="final">
+            OUI
+        </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">197</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/base/detail/detail.component.html</context>
+          <context context-type="linenumber">197</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context>
+          <context context-type="linenumber">245</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context>
+          <context context-type="linenumber">265</context>
+        </context-group>
+        <note priority="1" from="description">Yes</note>
+      </trans-unit>
       <trans-unit id="scrollForMore" datatype="html">
         <source>Scrollez pour en voir plus !</source><target state="final">Scrollez pour en voir plus !</target>
 
@@ -643,7 +1334,32 @@
         <source>Prochain</source><target state="final">Prochain</target>
 
         <note priority="1" from="description">Carousel next</note>
-      <context-group purpose="location"><context context-type="sourcefile">app/home/home.component.html</context><context context-type="linenumber">127</context></context-group></trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/home/home.component.html</context><context context-type="linenumber">127</context></context-group></trans-unit><trans-unit id="pageNotFoundTitle" datatype="html">
+        <source>Page non trouvé</source><target state="final">Page non trouvé</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/page-not-found/page-not-found.component.html</context>
+          <context context-type="linenumber">6</context>
+        </context-group>
+        <note priority="1" from="description">Title for 404 error page</note>
+      </trans-unit><trans-unit id="error404Text" datatype="html">
+        <source>Erreur 404</source><target state="final">Erreur 404</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/page-not-found/page-not-found.component.html</context>
+          <context context-type="linenumber">13</context>
+        </context-group>
+        <note priority="1" from="description">Text for 404 error</note>
+      </trans-unit><trans-unit id="homeLink" datatype="html">
+        <source>Accueil</source><target state="final">Accueil</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">custom/footer/footer.html</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+        <note priority="1" from="description">Home link</note>
+      </trans-unit><trans-unit id="aboutLink" datatype="html">
+        <source>A propos</source><target state="final">A propos</target>
+        
+        <note priority="1" from="description">About link</note>
+      <context-group purpose="location"><context context-type="sourcefile">custom/footer/footer.html</context><context context-type="linenumber">6</context></context-group></trans-unit>
       <trans-unit id="logout" datatype="html">
         <source>Se déconnecter</source><target state="final">Se déconnecter</target>
 
@@ -677,7 +1393,52 @@
         <source>Mon tableau de bord</source><target state="final">Mon tableau de bord</target>
 
         <note priority="1" from="description">my Dasboard Link</note>
-      <context-group purpose="location"><context context-type="sourcefile">app/core/topbar/topbar.component.html</context><context context-type="linenumber">54</context></context-group></trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/core/topbar/topbar.component.html</context><context context-type="linenumber">54</context></context-group></trans-unit><trans-unit id="myObservationsButton" datatype="html">
+        <source>
+                            Mes observations
+                            <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong>"/><x id="INTERPOLATION" equiv-text="{{
+                                stats?.platform_attendance
+                                }}"/><x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong>"/>
+                        </source><target state="final">
+                            Mes observations
+                            <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong>"/><x id="INTERPOLATION" equiv-text="{{
+                                stats?.platform_attendance
+                                }}"/><x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong>"/>
+                        </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context>
+          <context context-type="linenumber">13</context>
+        </context-group>
+        <note priority="1" from="description">Observations button</note>
+      </trans-unit><trans-unit id="mySitesButton" datatype="html">
+        <source>
+                            Mes sites
+                            <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong>"/><x id="INTERPOLATION" equiv-text="{{
+                                mysites?.features.length
+                                }}"/><x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong>"/>
+                        </source><target state="final">
+                            Mes sites
+                            <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong>"/><x id="INTERPOLATION" equiv-text="{{
+                                mysites?.features.length
+                                }}"/><x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong>"/>
+                        </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context>
+          <context context-type="linenumber">22</context>
+        </context-group>
+        <note priority="1" from="description">Sites button</note>
+      </trans-unit><trans-unit id="username" datatype="html">
+        <source>
+                        <x id="INTERPOLATION" equiv-text="{{ username }}"/> <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i>"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i>"/>
+                    </source><target state="final">
+                        <x id="INTERPOLATION" equiv-text="{{ username }}"/> <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i>"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i>"/>
+                    </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context>
+          <context context-type="linenumber">34</context>
+        </context-group>
+        <note priority="1" from="description">Username</note>
+      </trans-unit>
       <trans-unit id="myBadges" datatype="html">
         <source>Mes badges</source><target state="final">Mes badges</target>
 
@@ -691,7 +1452,21 @@
                     </target>
 
         <note priority="1" from="description">General Awards</note>
-      <context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">42</context></context-group></trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">42</context></context-group></trans-unit><trans-unit id="programAwards" datatype="html">
+        <source>Récompenses par programmes</source><target state="final">Récompenses par programmes</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context>
+          <context context-type="linenumber">54</context>
+        </context-group>
+        <note priority="1" from="description">Program Awards</note>
+      </trans-unit><trans-unit id="recognitionAwards" datatype="html">
+        <source>Récompenses d'identification d'espèces</source><target state="final">Récompenses d'identification d'espèces</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context>
+          <context context-type="linenumber">64</context>
+        </context-group>
+        <note priority="1" from="description">Recognition Awards</note>
+      </trans-unit>
       <trans-unit id="exportPersonnalDataBtn" datatype="html">
         <source>Exporter mes données
                         personnelles</source><target state="final">Exporter mes données
@@ -717,7 +1492,14 @@
                         compte</target>
 
         <note priority="1" from="description">Delete Account</note>
-      <context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">95</context></context-group></trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">95</context></context-group></trans-unit><trans-unit id="backSite" datatype="html">
+        <source>Retour au site</source><target state="final">Retour au site</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context>
+          <context context-type="linenumber">102</context>
+        </context-group>
+        <note priority="1" from="description">back</note>
+      </trans-unit>
       <trans-unit id="updatePersonnalData" datatype="html">
         <source>
             Mettre à jour vos données personnelles
@@ -726,43 +1508,43 @@
         </target>
 
         <note priority="1" from="description">Update personnal data</note>
-      <context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">112</context></context-group></trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">111</context></context-group></trans-unit>
       <trans-unit id="yourUsernameInputPlaceholder" datatype="html">
         <source>Entrez votre nom d'utilisateur</source><target state="final">Entrez votre nom d'utilisateur</target>
 
         <note priority="1" from="description">
                                     your username
                                     placeholder</note>
-      <context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">146</context></context-group></trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">145</context></context-group></trans-unit>
       <trans-unit id="yourEmailInputLabel" datatype="html">
         <source>Votre email *</source><target state="final">Votre email *</target>
 
         <note priority="1" from="description">your email label</note>
-      <context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">152</context></context-group></trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">151</context></context-group></trans-unit>
       <trans-unit id="yourFirstnameInputLabel" datatype="html">
         <source>Votre prénom *</source><target state="final">Votre prénom *</target>
 
         <note priority="1" from="description">your first name</note>
-      <context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">168</context></context-group></trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">167</context></context-group></trans-unit>
       <trans-unit id="yourFirstnameInputPlaceholder" datatype="html">
         <source>Entrez votre prénom</source><target state="final">Entrez votre prénom</target>
 
         <note priority="1" from="description">
                                 your first name
                                 placeholder</note>
-      <context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">172</context></context-group></trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">171</context></context-group></trans-unit>
       <trans-unit id="yourSurnameInputLabel" datatype="html">
         <source>Votre nom *</source><target state="final">Votre nom *</target>
 
         <note priority="1" from="description">your surname label</note>
-      <context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">177</context></context-group></trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">176</context></context-group></trans-unit>
       <trans-unit id="yourSurnameInputPlaceholder" datatype="html">
         <source>Entrez votre nom</source><target state="final">Entrez votre nom</target>
 
         <note priority="1" from="description">
                                 your surname
                                 placeholder</note>
-      <context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">181</context></context-group></trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">180</context></context-group></trans-unit>
       <trans-unit id="errorDifferentPasswords" datatype="html">
         <source>
                 Les mots de passe diffèrent.
@@ -771,35 +1553,46 @@
             </target>
 
         <note priority="1" from="description">error different passwords</note>
-      <context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">189</context></context-group></trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">188</context></context-group></trans-unit>
       <trans-unit id="yourPasswordLabel" datatype="html">
         <source>Votre nouveau mot de
                             passe</source><target state="final">Votre nouveau mot de
                             passe</target>
 
         <note priority="1" from="description">your password label</note>
-      <context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">195</context></context-group></trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">194</context></context-group></trans-unit>
       <trans-unit id="yourPasswordPlaceholder" datatype="html">
         <source>Votre nouveau mot de passe</source><target state="final">Votre nouveau mot de passe</target>
 
         <note priority="1" from="description">
                                 your password
                                 placeholder</note>
-      <context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">200</context></context-group></trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">199</context></context-group></trans-unit>
       <trans-unit id="yourConfirmPasswordLabel" datatype="html">
         <source>Confirmez votre nouveau mot de passe</source><target state="final">Confirmez votre nouveau mot de passe</target>
 
         <note priority="1" from="description">
                                 your password confirm
                                 label</note>
-      <context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">208</context></context-group></trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">207</context></context-group></trans-unit>
       <trans-unit id="yourConfirmPasswordPlaceholder" datatype="html">
         <source>Votre nouveau mot de passe</source><target state="final">Votre nouveau mot de passe</target>
 
         <note priority="1" from="description">
                                 your password confirm
                                 placeholder</note>
-      <context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">212</context></context-group></trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">211</context></context-group></trans-unit><trans-unit id="passwordMismatch" datatype="html">
+        <source>
+                            * Le mot de passe n'est pas identique.
+                        </source><target state="final">
+                            * Le mot de passe n'est pas identique.
+                        </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context>
+          <context context-type="linenumber">217</context>
+        </context-group>
+        <note priority="1" from="description">Password mismatch</note>
+      </trans-unit>
       <trans-unit id="updatePersonnalDataBtn" datatype="html">
         <source>
                 Mettre à jour
@@ -808,7 +1601,131 @@
             </target>
 
         <note priority="1" from="description">update personnal data btn</note>
-      <context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">226</context></context-group></trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context><context context-type="linenumber">225</context></context-group></trans-unit><trans-unit id="deleteObservationConfirmation" datatype="html">
+        <source>
+        Êtes-vous sûr de vouloir supprimer cette observation ?
+        <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/>"/>
+        Sa suppression sera définitive
+    </source><target state="final">
+        Êtes-vous sûr de vouloir supprimer cette observation ?
+        <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/>"/>
+        Sa suppression sera définitive
+    </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context>
+          <context context-type="linenumber">236</context>
+        </context-group>
+        <note priority="1" from="description">Delete observation confirmation</note>
+      </trans-unit><trans-unit id="deleteSiteConfirmation" datatype="html">
+        <source>
+        Êtes-vous sûr de vouloir supprimer ce site et toutes les informations
+        qui y sont rattachées ?
+        <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/>"/>
+        La suppression sera définitive
+    </source><target state="final">
+        Êtes-vous sûr de vouloir supprimer ce site et toutes les informations
+        qui y sont rattachées ?
+        <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/>"/>
+        La suppression sera définitive
+    </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/auth/user-dashboard/user-dashboard.component.html</context>
+          <context context-type="linenumber">255</context>
+        </context-group>
+        <note priority="1" from="description">Delete site confirmation</note>
+      </trans-unit><trans-unit id="proposedIdentification" datatype="html">
+        <source>
+            Identification proposée : 
+            <x id="START_TAG_NG-CONTAINER" ctype="x-ng-container" equiv-text="&lt;ng-container>"/><x id="INTERPOLATION" equiv-text="{{ obsToValidate.properties.nom_francais || obsToValidate.properties.taxref.nom_vern }}"/><x id="CLOSE_TAG_NG-CONTAINER" ctype="x-ng-container" equiv-text="&lt;/ng-container>"/>
+            <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span>"/>
+              (<x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i>"/><x id="INTERPOLATION_1" equiv-text="{{ obsToValidate.properties.taxref.lb_nom }}"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i>"/>)
+            <x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span>"/>
+          </source><target state="final">
+            Identification proposée : 
+            <x id="START_TAG_NG-CONTAINER" ctype="x-ng-container" equiv-text="&lt;ng-container>"/><x id="INTERPOLATION" equiv-text="{{ obsToValidate.properties.nom_francais || obsToValidate.properties.taxref.nom_vern }}"/><x id="CLOSE_TAG_NG-CONTAINER" ctype="x-ng-container" equiv-text="&lt;/ng-container>"/>
+            <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span>"/>
+              (<x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i>"/><x id="INTERPOLATION_1" equiv-text="{{ obsToValidate.properties.taxref.lb_nom }}"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i>"/>)
+            <x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span>"/>
+          </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/observations/validation/validation.component.html</context>
+          <context context-type="linenumber">30</context>
+        </context-group>
+        <note priority="1" from="description">Title for identification proposed</note>
+      </trans-unit><trans-unit id="speciesSearchOrValidation" datatype="html">
+        <source>{VAR_SELECT, select, isOn {Rechercher une espèce} isOff {Validez ou corrigez l'espèce} }</source><target state="final">{VAR_SELECT, select, isOn {Rechercher une espèce} isOff {Validez ou corrigez l'espèce} }</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/observations/validation/validation.component.html</context>
+          <context context-type="linenumber">39</context>
+        </context-group>
+        <note priority="1" from="description">Label for species search or validation</note>
+      </trans-unit><trans-unit id="notifyObserverLabel" datatype="html">
+        <source>
+                Avertir l'observateur
+            </source><target state="final">
+                Avertir l'observateur
+            </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/observations/validation/validation.component.html</context>
+          <context context-type="linenumber">128</context>
+        </context-group>
+        <note priority="1" from="description">Label for notifying the observer</note>
+      </trans-unit><trans-unit id="observerNotificationDescription" datatype="html">
+        <source>L'observateur recevra un mail contenant des informations de validation,
+                correction ou d'invalidité de son observation.</source><target state="final">L'observateur recevra un mail contenant des informations de validation,
+                correction ou d'invalidité de son observation.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/observations/validation/validation.component.html</context>
+          <context context-type="linenumber">131</context>
+        </context-group>
+        <note priority="1" from="description">Description for observer notification</note>
+      </trans-unit><trans-unit id="unvalidableObservationLabel" datatype="html">
+        <source>
+            Si l'observation est non validable en l'état :
+        </source><target state="final">
+            Si l'observation est non validable en l'état :
+        </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/observations/validation/validation.component.html</context>
+          <context context-type="linenumber">136</context>
+        </context-group>
+        <note priority="1" from="description">Label for unvalidable observation</note>
+      </trans-unit><trans-unit id="requestObserverModification" datatype="html">
+        <source>Demander à l'observateur de modifier son observation ou a un autre
+                    validateur de la vérifier.</source><target state="final">Demander à l'observateur de modifier son observation ou a un autre
+                    validateur de la vérifier.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/observations/validation/validation.component.html</context>
+          <context context-type="linenumber">146</context>
+        </context-group>
+        <note priority="1" from="description">Request for observer modification or validator check</note>
+      </trans-unit><trans-unit id="obsActionBtn" datatype="html">
+        <source>
+            <x id="ICU" equiv-text="{ obsValidatable, select, true {...} false {...}}"/>
+        </source><target state="final">
+            <x id="ICU" equiv-text="{ obsValidatable, select, true {...} false {...}}"/>
+        </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/observations/validation/validation.component.html</context>
+          <context context-type="linenumber">154</context>
+        </context-group>
+        <note priority="1" from="description">Button for validating, correcting, or invalidating an observation</note>
+      </trans-unit><trans-unit id="a5cf87dd6048bc6d23f027b10d8a50f741000bc3" datatype="html">
+        <source>{VAR_SELECT_1, select, true {{VAR_SELECT, select, true {Corriger l'observation} false {Valider l'observation} }
+                    } false {Invalider l'observation} }</source><target state="final">{VAR_SELECT_1, select, true {{VAR_SELECT, select, true {Corriger l'observation} false {Valider l'observation} }
+                    } false {Invalider l'observation} }</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/programs/observations/validation/validation.component.html</context>
+          <context context-type="linenumber">155</context>
+        </context-group>
+      </trans-unit><trans-unit id="discoverINPN" datatype="html">
+        <source>Découvrir sur INPN</source><target state="final">Découvrir sur INPN</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/synthesis/species/species.component.html</context>
+          <context context-type="linenumber">20</context>
+        </context-group>
+        <note priority="1" from="description">Link to INPN</note>
+      </trans-unit>
       <trans-unit id="redirectToHome" datatype="html">
         <source>vous allez être redirigé automatiquement sur la page d'accueil</source><target state="final">vous allez être redirigé automatiquement sur la page d'accueil</target>
         <context-group purpose="location">


### PR DESCRIPTION
Add translation deutsch and missing ones for english

- Generate the translation with the command `ng xi18n --output-path src/i18n --i18n-format xlf --i18n-locale de`
- Change angular.json
- Translate messages.de.xlf
- Add "de" to app.config.ts.template
- Add script to package.json
 - Add missing i18n translations in templates
 - Add missing i18n translations in xlf files
 - Add build for "de" in script package.json
 - Add "de" in server.ts file 
 - Add config translation "de" in map.config.template