### PR TITLE
[Frontend build] Always use server side rendering

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -417,13 +417,13 @@ Après chaque modification sur un des éléments qui concerne le frontend, il fa
 ::
 
   cd ~/gncitizen/frontend/
-  npm run ng build -- --prod
+  npm run build:i18n-ssr
 
 Si vous souhaitez que l'application soit disponible depuis un chemin spécifique (ex: ``mondomaine.org/citizen``), remplacez la dernière commande par
 
 ::
 
-  npm run ng build -- --prod --base-href=/citizen/
+  npm run build:i18n-ssr --base-href=/citizen/
 
 
 Lancement des services

--- a/install/update_app.sh
+++ b/install/update_app.sh
@@ -2,24 +2,22 @@
 
 cd $(dirname $(dirname "${BASH_SOURCE[0]:-$0}"))
 
-#Mise à jour du git
-
+# Mise à jour du git
 git pull
 
 . config/settings.ini
 npm install
-#Transpilation du frontend
+
+# Transpilation du frontend
 cd frontend
 npm install
-if [ $server_side = "true" ]; then
-  echo "Build server side project"
-  npm run build:i18n-ssr
-  echo "Reloading Front server ..."
-  sudo -s supervisorctl reload geonature
-else
-  echo "Build du projet"
-  npm run build
-fi
+
+echo "Build frontend"
+npm run build:i18n-ssr
+
+echo "Reloading Front server ..."
+sudo -s supervisorctl reload geonature
+
 cd ..
 
 # Mise a jour des requirements
@@ -31,6 +29,6 @@ source $venv_path/bin/activate
 echo $(pwd)
 pip install -r backend/requirements.txt
 
-#Reload Supervisor pour l'api
+# Reload Supervisor pour l'api
 echo "Reloading Api ..."
 sudo -s supervisorctl reload api_geonature


### PR DESCRIPTION
Cette PR généralise l'usage du build frontend en mode "Server Side Rendering" (SSR), à privilégier pour le référencement des applications Single Page telles que Citizen.

* Le script update_app.sh n'attend plus d'argument `$server_side`, et lance systématiquement le rebuild du frontend avec la commande `npm run build:i18n-ssr` (sur le modèle de ce qui se fait dans le script `install_app.sh`)
* Màj de la doc pour indiquer au gestionnaire d'utiliser la commande SSR en cas de changement de la configuration.