### PR TITLE
Fix error while saving data on chrome based browsers

### DIFF
--- a/frontend/src/app/programs/observations/form/form.component.html
+++ b/frontend/src/app/programs/observations/form/form.component.html
@@ -32,11 +32,11 @@
                     taxaCount >= taxonSelectInputThreshold &&
                     taxaCount < taxonAutocompleteInputThreshold
                 " class="d-inline-flex toolbar">
-                        <select formControlName="cd_nom" class="form-control w-100" required>
+                        <select formControlName="cd_nom" class="form-control w-100" required
+                            (change)="onTaxonSelectedByCdNom($event.target.value)">
                             <option [value]="" [disabled]="true" i18n="Option to choose a species@@chooseSpeciesOption">
                                 Choisissez une espèce</option>
-                            <option *ngFor="let s of surveySpecies" (click)="onTaxonSelected(s)"
-                                [value]="s.taxref.cd_nom">
+                            <option *ngFor="let s of surveySpecies" [value]="s.taxref.cd_nom">
                                 {{ getPreferredName(s) }}
                                 <span *ngIf="MainConfig.taxonDisplaySciName">(<i>{{ s.taxref.nom_complet }}</i>)</span>
                             </option>
@@ -71,7 +71,7 @@
                     class="form-group col-lg input-search-autocomplete">
                     <taxonomy-autocomplete label="" placeholder="Rechercher par nom ou cd_nom"
                         [parentFormControl]="obsForm.controls.cd_nom" [idList]="taxonomyListID" [charNumber]="3"
-                        [listLength]="20" (onChange)="onSelectedTaxon($event)">
+                        [listLength]="20" (onChange)="onAutocompleteSelectedTaxon($event)">
                     </taxonomy-autocomplete>
                 </div>
             </div>

--- a/frontend/src/app/programs/observations/form/form.component.ts
+++ b/frontend/src/app/programs/observations/form/form.component.ts
@@ -540,6 +540,16 @@ export class ObsFormComponent implements AfterViewInit {
         this.selectedTaxon = taxon;
         this.obsForm.controls['cd_nom'].patchValue(taxon.taxref['cd_nom']);
         this.obsForm.controls['name'].patchValue(getPreferredName(taxon));
+        console.log('<onTaxonSelected> this.obsForm.controls[name]', this.obsForm.controls['name'])
+    }
+
+    onTaxonSelectedByCdNom(cdNom: string): void {
+        const taxon = this.surveySpecies.find(
+            (species) => species.taxref.cd_nom.toString() === cdNom
+        );
+        if (taxon) {
+            this.onTaxonSelected(taxon);
+        }
     }
 
     onChangeContactCheckBoxRGPD(): void {
@@ -573,6 +583,7 @@ export class ObsFormComponent implements AfterViewInit {
         );
         formData.append('cd_nom', (this.obsForm.get('cd_nom').value).toString());
         formData.append('name', this.obsForm.get('name').value);
+        console.log('<createFormDataToPost> this.obsForm.get(name).value', this.obsForm.get('name').value)
         const obsDateControlValue = NgbDate.from(
             this.obsForm.controls.date.value
         );


### PR DESCRIPTION
Cette PR corrige la sauvegarde des observations qui échoue sous chromium (et google chrome ou tout autre navigateur basé sur chrome ?). 

En cause? Les manières différentes de gérer les évènements sur le select...